### PR TITLE
feat: add support for including all modified files

### DIFF
--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -9,10 +9,14 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-type Client struct{}
+type Client struct {
+	AddAll bool
+}
 
-func NewClient() *Client {
-	return &Client{}
+func NewClient(addAll bool) *Client {
+	return &Client{
+		AddAll: addAll,
+	}
 }
 
 func (c *Client) IsInWorkTree() error {
@@ -35,16 +39,17 @@ func (c *Client) IsInWorkTree() error {
 	return nil
 }
 
-func (c *Client) StagedFiles() ([]string, error) {
-	result, err := exec.Command(
-		"git",
-		"diff",
-		"--staged",
-		"--name-only",
-	).CombinedOutput()
+func (c *Client) ModifiedFiles() ([]string, error) {
+	args := []string{"diff", "--name-only"}
+	if c.AddAll {
+		args = append(args, "HEAD")
+	} else {
+		args = append(args, "--staged")
+	}
 
+	result, err := exec.Command("git", args...).CombinedOutput()
 	if err != nil {
-		return nil, errors.Wrap(err, "listing staged files failed")
+		return nil, errors.Wrap(err, "listing modified files failed")
 	}
 
 	trimmed := strings.TrimSpace(string(result))
@@ -55,13 +60,20 @@ func (c *Client) StagedFiles() ([]string, error) {
 }
 
 func (c *Client) Diff() (string, error) {
-	result, err := exec.Command(
-		"git",
+	args := []string{
 		"--no-pager",
 		"diff",
 		"--no-ext-diff",
 		"--no-textconv",
-		"--staged",
+	}
+
+	if c.AddAll {
+		args = append(args, "HEAD")
+	} else {
+		args = append(args, "--staged")
+	}
+
+	args = append(args,
 		"--diff-filter=ACMRTUXBD",
 		"--",                 // separates options from pathspecs
 		".",                  // include everything under the repo root
@@ -72,8 +84,9 @@ func (c *Client) Diff() (string, error) {
 		":(exclude)**/target/**",
 		":(exclude)**/out/**",
 		":(exclude)go.sum",
-	).CombinedOutput()
+	)
 
+	result, err := exec.Command("git", args...).CombinedOutput()
 	if err != nil {
 		return "", errors.Wrap(err, "git diff failed")
 	}
@@ -97,7 +110,13 @@ func (c *Client) Commit(message string) error {
 	}
 
 	// Set up git commit command
-	cmd := exec.Command("git", "commit", "-F", tmpfile.Name())
+	args := []string{"commit"}
+	if c.AddAll {
+		args = append(args, "-a")
+	}
+	args = append(args, "-F", tmpfile.Name())
+
+	cmd := exec.Command("git", args...)
 
 	// Connect stdout/stderr of git to our program’s stdout/stderr
 	cmd.Stdout = os.Stdout

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -10,12 +10,12 @@ import (
 )
 
 type Client struct {
-	AddAll bool
+	addAll bool
 }
 
 func NewClient(addAll bool) *Client {
 	return &Client{
-		AddAll: addAll,
+		addAll: addAll,
 	}
 }
 
@@ -41,7 +41,7 @@ func (c *Client) IsInWorkTree() error {
 
 func (c *Client) ModifiedFiles() ([]string, error) {
 	args := []string{"diff", "--name-only"}
-	if c.AddAll {
+	if c.addAll {
 		args = append(args, "HEAD")
 	} else {
 		args = append(args, "--staged")
@@ -67,7 +67,7 @@ func (c *Client) Diff() (string, error) {
 		"--no-textconv",
 	}
 
-	if c.AddAll {
+	if c.addAll {
 		args = append(args, "HEAD")
 	} else {
 		args = append(args, "--staged")
@@ -111,7 +111,7 @@ func (c *Client) Commit(message string) error {
 
 	// Set up git commit command
 	args := []string{"commit"}
-	if c.AddAll {
+	if c.addAll {
 		args = append(args, "-a")
 	}
 	args = append(args, "-F", tmpfile.Name())

--- a/internal/interfaces/git.go
+++ b/internal/interfaces/git.go
@@ -6,7 +6,7 @@ var ErrAborted = errors.New("aborted")
 
 type GitClient interface {
 	IsInWorkTree() error
-	StagedFiles() ([]string, error)
+	ModifiedFiles() ([]string, error)
 	Diff() (string, error)
 	Commit(message string) error
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -96,7 +96,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case gitCheckMsg:
 		if len(msg) == 0 {
-			m.err = errors.New("no changes are staged")
+			m.err = errors.New("no changes detected")
 			return m, tea.Quit
 		}
 		return m, m.getGitDiff

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -74,7 +74,7 @@ func InitialModel(
 		systemPrompt:   systemPrompt,
 		userMessage:    userMessage,
 		spinner:        spinner.New(spinner.WithSpinner(spinner.MiniDot)),
-		spinnerMessage: Magenta.Render("Running git commands to determine modified changes..."),
+		spinnerMessage: Magenta.Render("Running git commands to determine modified files..."),
 		action:         None,
 	}
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -74,7 +74,7 @@ func InitialModel(
 		systemPrompt:   systemPrompt,
 		userMessage:    userMessage,
 		spinner:        spinner.New(spinner.WithSpinner(spinner.MiniDot)),
-		spinnerMessage: Magenta.Render("Running git commands to determine staged changes..."),
+		spinnerMessage: Magenta.Render("Running git commands to determine modified changes..."),
 		action:         None,
 	}
 }
@@ -198,11 +198,11 @@ func (m *Model) checkGitStatus() tea.Msg {
 	if err := m.gitClient.IsInWorkTree(); err != nil {
 		return errMsg{err}
 	}
-	stagedFiles, err := m.gitClient.StagedFiles()
+	modifiedFiles, err := m.gitClient.ModifiedFiles()
 	if err != nil {
 		return errMsg{err}
 	}
-	return gitCheckMsg(stagedFiles)
+	return gitCheckMsg(modifiedFiles)
 }
 
 func (m *Model) getGitDiff() tea.Msg {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -41,7 +41,7 @@ func (m *MockGitClient) IsInWorkTree() error {
 	return args.Error(0)
 }
 
-func (m *MockGitClient) StagedFiles() ([]string, error) {
+func (m *MockGitClient) ModifiedFiles() ([]string, error) {
 	args := m.Called()
 	return args.Get(0).([]string), args.Error(1)
 }

--- a/main.go
+++ b/main.go
@@ -60,7 +60,8 @@ func main() {
 			provider, err := llmprovider.NewProvider(ctx, cfg)
 			handleError(err)
 
-			application := app.NewApp(provider, git.NewClient(), cfg.Prompt)
+			addAll, _ := cmd.Flags().GetBool("all")
+			application := app.NewApp(provider, git.NewClient(addAll), cfg.Prompt)
 			err = application.Run(ctx, userMessage)
 			if err != nil {
 				handleError(err)
@@ -72,6 +73,7 @@ func main() {
 	runSetupWizard = rootCmd.PersistentFlags().Bool("setup-wizard", false, "Run setup wizard")
 	rootCmd.PersistentFlags().StringVarP(&userMessage, "message", "m", "", "Append a message to the commit summary")
 	rootCmd.PersistentFlags().StringVar(&llmProvider, "llm-provider", cfg.LLMProvider, "Use specific LLM provider, overrides environment variable LLM_PROVIDER")
+	rootCmd.PersistentFlags().BoolP("all", "a", false, "Add all tracked files to the commit")
 
 	_ = rootCmd.Execute()
 }


### PR DESCRIPTION
Introduced an optional `AddAll` flag to the `GitClient` to allow committing unstaged changes.

- Updated `GitClient` to support `git add -a` equivalent behavior.
- Refactored `StagedFiles` to `ModifiedFiles` to reflect the broader scope.
- Added `--all` flag to the CLI.

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant GitClient

    User->>CLI: Run with --all
    CLI->>GitClient: NewClient(true)
    CLI->>GitClient: ModifiedFiles()
    GitClient-->>CLI: Returns all tracked modified files
    CLI->>GitClient: Commit()
    GitClient->>GitClient: Executes git commit -a
```