### PR TITLE
feat: separate system instructions and user prompts

### DIFF
--- a/internal/config/prompt.md
+++ b/internal/config/prompt.md
@@ -1,18 +1,11 @@
 You are a coding assistant that writes concise, conventional commit messages.
-Always start with one of these verbs: feat, fix, chore, docs, style, refactor, test, perf.
 
--   Write a **short** message (max 50 characters) as the first line summarizing the diff output
-    that follows.
--   You may additionally include a blank line and a longer description explaining what and
-    why, but not how.
--   Use markdown for emphasis (code blocks, bold, links) if they adds value.
--   You can use bullet points.
--   Wrap description lines at max 72 characters: Do **NOT** exceed 72 characters per line.
--   If the pull request is complex and you think that a sequence diagram (or entity relationship
-    diagram) would help explain the changes, include one or more mermaid diagrams in markdown
-    format.
--   There is no need to mention: "Note: This commit message is concise and follows the
-    conventional commit message format...."
+- Use these verbs: feat, fix, chore, docs, style, refactor, test, perf.
+- Start with a short summary (max 50 chars).
+- Optionally, add a blank line and a longer description (what and why, not how).
+- Keep lines under 72 chars.
+- Use markdown if it adds value (bullet points, bold, code blocks).
+- Include mermaid diagrams for complex changes if helpful.
 
 Diff follows:
 
@@ -20,6 +13,4 @@ Diff follows:
 %s
 ```
 
-Note that if the diff is empty, it is likely there **are** staged changes, but they have
-been excluded because they are too big to be shown. In that case, just reply with a
-completely blank response.
+If the diff is empty, just reply with a blank response.

--- a/internal/llm_provider/google.go
+++ b/internal/llm_provider/google.go
@@ -26,11 +26,18 @@ func NewGoogleProvider(ctx context.Context, cfg *config.Config) (Provider, error
 }
 
 func (provider *GoogleProvider) Call(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	config := &genai.GenerateContentConfig{}
+	if systemPrompt != "" {
+		config.SystemInstruction = &genai.Content{
+			Parts: []*genai.Part{genai.NewPartFromText(systemPrompt)},
+		}
+	}
+
 	result, err := provider.client.Models.GenerateContent(
 		ctx,
 		provider.model,
 		genai.Text(userPrompt),
-		nil,
+		config,
 	)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to generate content:")

--- a/internal/llm_provider/openai.go
+++ b/internal/llm_provider/openai.go
@@ -27,13 +27,17 @@ func NewOpenAiProvider(ctx context.Context, cfg *config.Config) (Provider, error
 }
 
 func (provider *OpenAiProvider) Call(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	messages := []openai.ChatCompletionMessageParamUnion{
+		openai.UserMessage(userPrompt),
+	}
+	if systemPrompt != "" {
+		messages = append([]openai.ChatCompletionMessageParamUnion{openai.SystemMessage(systemPrompt)}, messages...)
+	}
+
 	result, err := provider.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
 		Temperature: openai.Float(0.1),
 		Model:       provider.model,
-		Messages: []openai.ChatCompletionMessageParamUnion{
-			openai.SystemMessage(systemPrompt),
-			openai.UserMessage(userPrompt),
-		},
+		Messages:    messages,
 	})
 	if err != nil {
 		return "", errors.Wrap(err, "failed to generate content")

--- a/internal/llm_provider/openai.go
+++ b/internal/llm_provider/openai.go
@@ -27,12 +27,11 @@ func NewOpenAiProvider(ctx context.Context, cfg *config.Config) (Provider, error
 }
 
 func (provider *OpenAiProvider) Call(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
-	messages := []openai.ChatCompletionMessageParamUnion{
-		openai.UserMessage(userPrompt),
-	}
+	var messages []openai.ChatCompletionMessageParamUnion
 	if systemPrompt != "" {
-		messages = append([]openai.ChatCompletionMessageParamUnion{openai.SystemMessage(systemPrompt)}, messages...)
+		messages = append(messages, openai.SystemMessage(systemPrompt))
 	}
+	messages = append(messages, openai.UserMessage(userPrompt))
 
 	result, err := provider.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
 		Temperature: openai.Float(0.1),

--- a/internal/llm_provider/openrouter.go
+++ b/internal/llm_provider/openrouter.go
@@ -21,12 +21,11 @@ func NewOpenRouterProvider(ctx context.Context, cfg *config.Config) (Provider, e
 }
 
 func (provider *OpenRouterProvider) Call(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
-	messages := []openrouter.ChatCompletionMessage{
-		openrouter.UserMessage(userPrompt),
-	}
+	var messages []openrouter.ChatCompletionMessage
 	if systemPrompt != "" {
-		messages = append([]openrouter.ChatCompletionMessage{openrouter.SystemMessage(systemPrompt)}, messages...)
+		messages = append(messages, openrouter.SystemMessage(systemPrompt))
 	}
+	messages = append(messages, openrouter.UserMessage(userPrompt))
 
 	result, err := provider.client.CreateChatCompletion(ctx, openrouter.ChatCompletionRequest{
 		Model:    provider.model,

--- a/internal/llm_provider/openrouter.go
+++ b/internal/llm_provider/openrouter.go
@@ -21,12 +21,16 @@ func NewOpenRouterProvider(ctx context.Context, cfg *config.Config) (Provider, e
 }
 
 func (provider *OpenRouterProvider) Call(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	messages := []openrouter.ChatCompletionMessage{
+		openrouter.UserMessage(userPrompt),
+	}
+	if systemPrompt != "" {
+		messages = append([]openrouter.ChatCompletionMessage{openrouter.SystemMessage(systemPrompt)}, messages...)
+	}
+
 	result, err := provider.client.CreateChatCompletion(ctx, openrouter.ChatCompletionRequest{
-		Model: provider.model,
-		Messages: []openrouter.ChatCompletionMessage{
-			openrouter.SystemMessage(systemPrompt),
-			openrouter.UserMessage(userPrompt),
-		},
+		Model:    provider.model,
+		Messages: messages,
 	})
 	if err != nil {
 		return "", errors.Wrap(err, "failed to generate content")

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -260,12 +260,28 @@ func (m *Model) getGitDiff() tea.Msg {
 
 func (m *Model) generateSummary(diff string, userMessage string) tea.Cmd {
 	return func() tea.Msg {
-		text := fmt.Sprintf(m.systemPrompt, diff)
-		if userMessage != "" {
-			text += "\n\n**IMPORTANT:** " + userMessage
+		var systemInstruction string
+		var userPrompt string
+
+		// Split the systemPrompt into instructions and the diff template.
+		// The prompt.md format is: [Instructions] \n\n Diff follows: \n\n ```diff %s ``` ...
+		parts := strings.SplitN(m.systemPrompt, "Diff follows:", 2)
+		if len(parts) < 2 {
+			// Fallback if "Diff follows:" is not found in the prompt template.
+			systemInstruction = ""
+			userPrompt = fmt.Sprintf(m.systemPrompt, diff)
+		} else {
+			systemInstruction = strings.TrimSpace(parts[0])
+			userPrompt = fmt.Sprintf(parts[1], diff)
 		}
+
+		if userMessage != "" {
+			// append the user supplied message
+			userPrompt += "\n\n**IMPORTANT:** " + userMessage
+		}
+
 		start := time.Now()
-		resp, err := m.llmProvider.Call(m.ctx, "", text)
+		resp, err := m.llmProvider.Call(m.ctx, systemInstruction, userPrompt)
 		duration := time.Since(start)
 		if err != nil {
 			return errMsg{err}


### PR DESCRIPTION
Split the prompt configuration into distinct system instructions and user
prompts, allowing LLM providers to receive them correctly.

- Updated LLM providers (Google, OpenAI, OpenRouter) to handle optional system instructions.
- Refactored `ui/model.go` to extract the system instructions from the prompt template and pass them separately to the provider.
- Simplified the `prompt.md` instructions.