### PR TITLE
chore: migrate release process to GoReleaser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,10 +97,3 @@ jobs:
           # fetch_all_tags: true    # optional if your repo has many tags
           # create_annotated_tag: true  # optional
 
-      - name: Create GitHub Release
-        if: steps.tag_version.outputs.new_tag != ''
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean ${{ github.event_name == 'workflow_dispatch' && '--snapshot' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ go.work.sum
 __debug_bin*
 git-commit-summary
 test-reports/
+.antigravitycli/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,28 @@
+version: 2
+
+project_name: git-commit-summary
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+brews:
+  - name: git-commit-summary
+    repository:
+      owner: rm-hull
+      name: homebrew-tap
+    homepage: "https://github.com/rm-hull/git-commit-summary"
+    description: "Command-line tool to automatically generates a concise git commit summary for your staged changes."

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
 
 archives:
   - format: tar.gz
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: "checksums.txt"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,4 +25,4 @@ brews:
       owner: rm-hull
       name: homebrew-tap
     homepage: "https://github.com/rm-hull/git-commit-summary"
-    description: "Command-line tool to automatically generates a concise git commit summary for your staged changes."
+    description: "Command-line tool to automatically generate a concise commit summary for staged changes in a git repo."


### PR DESCRIPTION
- Removed manual release step from `build.yml`.
- Added dedicated `release.yml` workflow to handle automated releases.
- Introduced `.goreleaser.yml` to define build and packaging configurations.
- Added `.antigravitycli/` to `.gitignore`.