### PR TITLE
feat: add `--skip-ci` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,16 @@ LLAMACPP_MODEL="Meta-Llama-3.1-8B-Instruct-Q4_K_M"
 
 ## Flags
 
-| Flag             | Shorthand | Description                                      |
-| :--------------- | :-------- | :----------------------------------------------- |
-| `--version`      | `-v`      | Display version                                  |
-| `--setup-wizard` |           | Run the interactive setup wizard                 |
-| `--message`      | `-m`      | Append a message to the commit summary           |
-| `--llm-provider` |           | Override the `LLM_PROVIDER` environment variable |
+| Flag             | Shorthand | Description                                                           |
+| :--------------- | :-------- | :-------------------------------------------------------------------- |
+| `--all`          | `-a`      | Add all tracked files to the commit                                   |
+| `--help`         | `-h       | Show help                                                             |
+| `--llm-provider` |           | Override the `LLM_PROVIDER` environment variable                      |
+| `--message`      | `-m`      | Append a message to the commit summary                                |
+| `--setup-wizard` |           | Run the interactive setup wizard                                      |
+| `--skip-ci`      |           | Append `[skip ci]` to the first line of the commit message to skip CI |
+| `--version`      | `-v`      | Display version                                                       |
+| `--yolo`         |           | Commit immediately without asking for confirmation                    |
 
 ## Git Alias
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ LLAMACPP_MODEL="Meta-Llama-3.1-8B-Instruct-Q4_K_M"
 | Flag             | Shorthand | Description                                                           |
 | :--------------- | :-------- | :-------------------------------------------------------------------- |
 | `--all`          | `-a`      | Add all tracked files to the commit                                   |
-| `--help`         | `-h       | Show help                                                             |
+| `--help`         | `-h`      | Show help                                                             |
 | `--llm-provider` |           | Override the `LLM_PROVIDER` environment variable                      |
 | `--message`      | `-m`      | Append a message to the commit summary                                |
 | `--setup-wizard` |           | Run the interactive setup wizard                                      |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -29,7 +29,7 @@ func NewApp(provider llmprovider.Provider, git interfaces.GitClient, prompt stri
 	}
 }
 
-func (app *App) Run(ctx context.Context, userMessage string, yolo bool) error {
+func (app *App) Run(ctx context.Context, userMessage string, yolo bool, skipCI bool) error {
 	model := ui.InitialModel(ctx, app.llmProvider, app.git, app.prompt, userMessage, yolo)
 	p := tea.NewProgram(model)
 
@@ -65,7 +65,7 @@ func (app *App) Run(ctx context.Context, userMessage string, yolo bool) error {
 			fmt.Println(m.CommitMessage())
 			fmt.Println()
 		}
-		err = app.git.Commit(m.CommitMessage())
+		err = app.git.Commit(m.CommitMessage(), skipCI)
 		if err != nil {
 			return err
 		}

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -93,7 +93,20 @@ func (c *Client) Diff() (string, error) {
 	return string(result), nil
 }
 
-func (c *Client) Commit(message string) error {
+func (c *Client) prepareCommitMessage(message string, skipCI bool) string {
+	if skipCI {
+		lines := strings.SplitN(message, "\n", 2)
+		if len(lines) == 1 {
+			return fmt.Sprintf("%s [skip ci]", message)
+		}
+		return fmt.Sprintf("%s [skip ci]\n%s", lines[0], lines[1])
+	}
+	return message
+}
+
+func (c *Client) Commit(message string, skipCI bool) error {
+	message = c.prepareCommitMessage(message, skipCI)
+
 	tmpfile, err := os.CreateTemp("", "gitmsg-*.txt")
 	if err != nil {
 		return err

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -94,12 +94,13 @@ func (c *Client) Diff() (string, error) {
 }
 
 func (c *Client) prepareCommitMessage(message string, skipCI bool) string {
-	if skipCI {
+	if skipCI && !strings.Contains(message, "[skip ci]") {
 		lines := strings.SplitN(message, "\n", 2)
+		subject := strings.TrimRight(lines[0], " \t")
 		if len(lines) == 1 {
-			return fmt.Sprintf("%s [skip ci]", message)
+			return fmt.Sprintf("%s [skip ci]", subject)
 		}
-		return fmt.Sprintf("%s [skip ci]\n%s", lines[0], lines[1])
+		return fmt.Sprintf("%s [skip ci]\n%s", subject, lines[1])
 	}
 	return message
 }

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -1,0 +1,56 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_prepareCommitMessage(t *testing.T) {
+	client := NewClient(false)
+
+	tests := []struct {
+		name     string
+		message  string
+		skipCI   bool
+		expected string
+	}{
+		{
+			name:     "Single line message with skipCI",
+			message:  "feat: something",
+			skipCI:   true,
+			expected: "feat: something [skip ci]",
+		},
+		{
+			name:     "Multi-line message with skipCI",
+			message:  "feat: something\n\nDetailed description",
+			skipCI:   true,
+			expected: "feat: something [skip ci]\n\nDetailed description",
+		},
+		{
+			name:     "Single line message without skipCI",
+			message:  "feat: something",
+			skipCI:   false,
+			expected: "feat: something",
+		},
+		{
+			name:     "Multi-line message without skipCI",
+			message:  "feat: something\n\nDetailed description",
+			skipCI:   false,
+			expected: "feat: something\n\nDetailed description",
+		},
+		{
+			name:     "Empty message with skipCI",
+			message:  "",
+			skipCI:   true,
+			expected: " [skip ci]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := client.prepareCommitMessage(tt.message, tt.skipCI)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/internal/interfaces/git.go
+++ b/internal/interfaces/git.go
@@ -8,5 +8,5 @@ type GitClient interface {
 	IsInWorkTree() error
 	ModifiedFiles() ([]string, error)
 	Diff() (string, error)
-	Commit(message string) error
+	Commit(message string, skipCI bool) error
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -52,8 +52,8 @@ func (m *MockGitClient) Diff() (string, error) {
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockGitClient) Commit(message string) error {
-	args := m.Called(message)
+func (m *MockGitClient) Commit(message string, skipCI bool) error {
+	args := m.Called(message, skipCI)
 	return args.Error(0)
 }
 

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 	var showVersion *bool
 	var yoloMode *bool
 	var addAll *bool
+	var skipCI *bool
 
 	rootCmd := &cobra.Command{
 		Use:   "git-commit-summary",
@@ -63,7 +64,7 @@ func main() {
 			handleError(err)
 
 			application := app.NewApp(provider, git.NewClient(*addAll), cfg.Prompt)
-			err = application.Run(ctx, userMessage, *yoloMode)
+			err = application.Run(ctx, userMessage, *yoloMode, *skipCI)
 			if err != nil {
 				handleError(err)
 			}
@@ -74,6 +75,7 @@ func main() {
 	runSetupWizard = rootCmd.PersistentFlags().Bool("setup-wizard", false, "Run setup wizard")
 	yoloMode = rootCmd.PersistentFlags().Bool("yolo", false, "Commit immediately without asking for confirmation")
 	addAll = rootCmd.PersistentFlags().BoolP("all", "a", false, "Add all tracked files to the commit")
+	skipCI = rootCmd.PersistentFlags().Bool("skip-ci", false, "Append [skip ci] to the commit message")
 	rootCmd.PersistentFlags().StringVarP(&userMessage, "message", "m", "", "Append a message to the commit summary")
 	rootCmd.PersistentFlags().StringVar(&llmProvider, "llm-provider", cfg.LLMProvider, "Use specific LLM provider, overrides environment variable LLM_PROVIDER")
 


### PR DESCRIPTION
- Added `--skip-ci` flag to append `[skip ci]` to commit messages.
- Updated `GitClient` and `App` to handle the new flag.
- Added unit tests for commit message formatting logic.
- Updated documentation in `README.md`.