### PR TITLE
feat: add `--hint` flag to provide context

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Tired of writing git commit messages? This tool uses AI ✨ to automatically gen
 
 - **Automatic Commit Summaries:** Analyzes your staged changes and generates ~~AI-slop~~ high-quality commit messages.
 - **Interactive Confirmation:** Prompts you to confirm the commit message before committing.
+- **Contextual Hints:** Provide additional context to the LLM via the `--hint` flag to improve relevance.
 - **Colorful Output:** Provides a visually appealing and easy-to-read output in your terminal.
 - **Multiple LLM Providers:** Supports Google Gemini, OpenAI, OpenRouter, and local Llama.cpp instances.
 - **Setup Wizard:** Easy configuration with an interactive setup wizard.
@@ -103,6 +104,7 @@ LLAMACPP_MODEL="Meta-Llama-3.1-8B-Instruct-Q4_K_M"
 | :--------------- | :-------- | :-------------------------------------------------------------------- |
 | `--all`          | `-a`      | Add all tracked files to the commit                                   |
 | `--help`         | `-h`      | Show help                                                             |
+| `--hint`         | `-H`      | Provide contextual guidance for the commit summary generation         |
 | `--llm-provider` |           | Override the `LLM_PROVIDER` environment variable                      |
 | `--message`      | `-m`      | Append a message to the commit summary                                |
 | `--setup-wizard` |           | Run the interactive setup wizard                                      |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -29,8 +29,8 @@ func NewApp(provider llmprovider.Provider, git interfaces.GitClient, prompt stri
 	}
 }
 
-func (app *App) Run(ctx context.Context, userMessage string, yolo bool, skipCI bool) error {
-	model := ui.InitialModel(ctx, app.llmProvider, app.git, app.prompt, userMessage, yolo)
+func (app *App) Run(ctx context.Context, userMessage, hint string, yolo, skipCI bool) error {
+	model := ui.InitialModel(ctx, app.llmProvider, app.git, app.prompt, userMessage, hint, yolo)
 	p := tea.NewProgram(model)
 
 	finalModel, err := p.Run()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -54,6 +54,7 @@ type Model struct {
 	gitClient      interfaces.GitClient
 	systemPrompt   string
 	userMessage    string
+	hint           string
 	diff           string
 	spinner        spinner.Model
 	spinnerMessage string
@@ -72,6 +73,7 @@ func InitialModel(
 	gitClient interfaces.GitClient,
 	systemPrompt string,
 	userMessage string,
+	hint string,
 	yolo bool,
 ) *Model {
 	return &Model{
@@ -81,6 +83,7 @@ func InitialModel(
 		gitClient:      gitClient,
 		systemPrompt:   systemPrompt,
 		userMessage:    userMessage,
+		hint:           hint,
 		spinner:        spinner.New(spinner.WithSpinner(spinner.MiniDot)),
 		spinnerMessage: Magenta.Render("Checking whether a newer version exists..."),
 		action:         None,
@@ -275,9 +278,13 @@ func (m *Model) generateSummary(diff string, userMessage string) tea.Cmd {
 			userPrompt = fmt.Sprintf(parts[1], diff)
 		}
 
+		if m.hint != "" {
+			userPrompt += fmt.Sprintf("\n\nCONTEXT HINT: %s", m.hint)
+		}
+
 		if userMessage != "" {
 			// append the user supplied message
-			userPrompt += "\n\n**IMPORTANT:** " + userMessage
+			userPrompt += fmt.Sprintf("\n\n**IMPORTANT:** %s", userMessage)
 		}
 
 		start := time.Now()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -279,12 +279,10 @@ func (m *Model) generateSummary(diff string, userMessage string) tea.Cmd {
 		}
 
 		if m.hint != "" {
-			userPrompt += fmt.Sprintf("\n\nCONTEXT HINT: %s", m.hint)
+			userPrompt += "\n\nCONTEXT HINT: " + m.hint
 		}
-
 		if userMessage != "" {
-			// append the user supplied message
-			userPrompt += fmt.Sprintf("\n\n**IMPORTANT:** %s", userMessage)
+			userPrompt += "\n\n**IMPORTANT:** " + userMessage
 		}
 
 		start := time.Now()

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,8 +23,8 @@ type MockLLMProvider struct {
 	mock.Mock
 }
 
-func (m *MockLLMProvider) Call(ctx context.Context, model string, prompt string) (string, error) {
-	args := m.Called(ctx, model, prompt)
+func (m *MockLLMProvider) Call(ctx context.Context, systemPrompt string, userPrompt string) (string, error) {
+	args := m.Called(ctx, systemPrompt, userPrompt)
 	return args.String(0), args.Error(1)
 }
 
@@ -67,7 +68,7 @@ func TestModel_Update(t *testing.T) {
 		// Explicitly use the types to avoid "imported and not used" warnings
 		var _ interfaces.GitClient = mockGit
 		var _ llmprovider.Provider = mockLLM
-		return InitialModel(ctx, mockLLM, mockGit, "system prompt", "user message", false)
+		return InitialModel(ctx, mockLLM, mockGit, "system prompt", "user message", "", false)
 	}
 
 	t.Run("tea.KeyMsg - CtrlC in showSpinner state", func(t *testing.T) {
@@ -124,19 +125,24 @@ func TestModel_Update(t *testing.T) {
 		mockGit.AssertExpectations(t)
 	})
 
-	t.Run("gitDiffMsg", func(t *testing.T) {
+	t.Run("gitDiffMsg with hint", func(t *testing.T) {
 		m := initialModel()
 		m.state = showSpinner // Ensure initial state is showSpinner
+		m.hint = "prioritize auth flow"
 		mockLLM.On("Model").Return("test-model").Once()
-		// The command returned by Update will execute llmProvider.Call later.
-		// No need to set mockLLM.On("Call") here.
 
 		diffContent := "diff --git a/file.go b/file.go"
+
+		// We want to check if the prompt passed to Call contains the hint.
+		mockLLM.On("Call", mock.Anything, "", mock.MatchedBy(func(p string) bool {
+			return strings.Contains(p, "CONTEXT HINT: prioritize auth flow")
+		})).Return("summary", nil).Once()
+
 		updatedModel, cmd := m.Update(gitDiffMsg(diffContent))
 
-		assert.Equal(t, diffContent, updatedModel.(*Model).diff)
-		assert.Contains(t, updatedModel.(*Model).spinnerMessage, "Generating commit summary (using: test-model)")
-		assert.IsType(t, tea.Batch(nil), cmd)
+		assert.Nil(t, updatedModel.(*Model).err)
+		assert.NotNil(t, cmd)
+		cmd() // Execute the command to trigger generateSummary
 		mockLLM.AssertExpectations(t)
 	})
 
@@ -294,7 +300,7 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("llmResultMsg - YOLO mode", func(t *testing.T) {
-		m := InitialModel(ctx, mockLLM, mockGit, "system prompt", "user message", true)
+		m := InitialModel(ctx, mockLLM, mockGit, "system prompt", "user message", "", true)
 		updatedModel, cmd := m.Update(llmResultMsg{content: "commit summary", duration: time.Second})
 
 		assert.Equal(t, Commit, updatedModel.(*Model).action)
@@ -304,7 +310,7 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("llmResultMsg - YOLO mode - empty summary", func(t *testing.T) {
-		m := InitialModel(ctx, mockLLM, mockGit, "system prompt", "", true)
+		m := InitialModel(ctx, mockLLM, mockGit, "system prompt", "", "", true)
 		updatedModel, cmd := m.Update(llmResultMsg{content: "", duration: time.Second})
 
 		assert.NotNil(t, updatedModel.(*Model).err)

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -142,7 +142,7 @@ func TestModel_Update(t *testing.T) {
 
 		assert.Nil(t, updatedModel.(*Model).err)
 		assert.NotNil(t, cmd)
-		cmd() // Execute the command to trigger generateSummary
+		cmd()
 		mockLLM.AssertExpectations(t)
 	})
 

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -133,7 +133,6 @@ func TestModel_Update(t *testing.T) {
 
 		diffContent := "diff --git a/file.go b/file.go"
 
-		// We want to check if the prompt passed to Call contains the hint.
 		mockLLM.On("Call", mock.Anything, "", mock.MatchedBy(func(p string) bool {
 			return strings.Contains(p, "CONTEXT HINT: prioritize auth flow")
 		})).Return("summary", nil).Once()

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func main() {
 	var yoloMode *bool
 	var addAll *bool
 	var skipCI *bool
+	var hint string
 
 	rootCmd := &cobra.Command{
 		Use:   "git-commit-summary",
@@ -64,7 +65,7 @@ func main() {
 			handleError(err)
 
 			application := app.NewApp(provider, git.NewClient(*addAll), cfg.Prompt)
-			err = application.Run(ctx, userMessage, *yoloMode, *skipCI)
+			err = application.Run(ctx, userMessage, hint, *yoloMode, *skipCI)
 			if err != nil {
 				handleError(err)
 			}
@@ -78,6 +79,7 @@ func main() {
 	skipCI = rootCmd.PersistentFlags().Bool("skip-ci", false, "Append [skip ci] to the commit message")
 	rootCmd.PersistentFlags().StringVarP(&userMessage, "message", "m", "", "Append a message to the commit summary")
 	rootCmd.PersistentFlags().StringVar(&llmProvider, "llm-provider", cfg.LLMProvider, "Use specific LLM provider, overrides environment variable LLM_PROVIDER")
+	rootCmd.PersistentFlags().StringVarP(&hint, "hint", "H", "", "Provide contextual guidance for the commit summary generation")
 
 	_ = rootCmd.Execute()
 }


### PR DESCRIPTION
Introduced a new `-H/--hint` flag to allow users to provide additional contextual guidance for the commit message generation. This hint is appended to the prompt sent to the LLM to improve the relevance of the generated summary.

Fixes: #105 