### PR TITLE
fix: re-enable help text when cancelling regeneration

### DIFF
--- a/internal/ui/commit_view.go
+++ b/internal/ui/commit_view.go
@@ -92,6 +92,7 @@ func initialCommitViewModel(message string, duration time.Duration) (*commitView
 
 func (m *commitViewModel) Init() tea.Cmd {
 	m.textarea.Focus()
+	m.helpText = true
 	return textarea.Blink
 }
 

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -226,10 +226,7 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("cancelRegenPromptMsg - re-enables help text", func(t *testing.T) {
-		ctx := context.Background()
-		mockLLM := new(MockLLMProvider)
-		mockGit := new(MockGitClient)
-		m := InitialModel(ctx, mockLLM, mockGit, "system prompt", "user message", "", false)
+		m := initialModel()
 		m.state = showRegeneratePrompt
 
 		// Create a real commitViewModel to check helpText

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -225,25 +225,28 @@ func TestModel_Update(t *testing.T) {
 		mockLLM.AssertExpectations(t)
 	})
 
-	t.Run("cancelRegenPromptMsg", func(t *testing.T) {
-		m := initialModel()
-		m.state = showRegeneratePrompt // Ensure state is showRegeneratePrompt
+	t.Run("cancelRegenPromptMsg - re-enables help text", func(t *testing.T) {
+		ctx := context.Background()
+		mockLLM := new(MockLLMProvider)
+		mockGit := new(MockGitClient)
+		m := InitialModel(ctx, mockLLM, mockGit, "system prompt", "user message", "", false)
+		m.state = showRegeneratePrompt
 
-		// Mock the sub-model's Init method
-		mockCommitView := new(mockTeaModel)
-		mockCommitView.On("Init").Return((tea.Cmd)(nil)).Once()
-		m.commitView = mockCommitView
+		// Create a real commitViewModel to check helpText
+		cv, err := initialCommitViewModel("test message", 0)
+		assert.NoError(t, err)
+		cv.helpText = false // Start with helpText disabled
+		m.commitView = cv
 
-		updatedModel, cmd := m.Update(cancelRegenPromptMsg{})
+		updatedModel, _ := m.Update(cancelRegenPromptMsg{})
 
 		assert.Equal(t, showCommitView, updatedModel.(*Model).state)
-		assert.Nil(t, cmd) // Should return m.commitView.Init() which is mocked to return nil
-		mockCommitView.AssertExpectations(t)
+		assert.True(t, cv.helpText, "helpText should be re-enabled after cancelling regeneration")
 	})
 
 	t.Run("errMsg", func(t *testing.T) {
 		m := initialModel()
-		m.state = showSpinner // Ensure state is showSpinner
+		m.state = showSpinner // Ensure initial state is showSpinner
 
 		testErr := errors.New("something went wrong")
 		updatedModel, cmd := m.Update(errMsg{err: testErr})

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -235,10 +235,11 @@ func TestModel_Update(t *testing.T) {
 		cv.helpText = false // Start with helpText disabled
 		m.commitView = cv
 
-		updatedModel, _ := m.Update(cancelRegenPromptMsg{})
+		updatedModel, cmd := m.Update(cancelRegenPromptMsg{})
 
 		assert.Equal(t, showCommitView, updatedModel.(*Model).state)
 		assert.True(t, cv.helpText, "helpText should be re-enabled after cancelling regeneration")
+		assert.NotNil(t, cmd, "Update should return a command from commitView.Init()")
 	})
 
 	t.Run("errMsg", func(t *testing.T) {


### PR DESCRIPTION
Ensure that `helpText` is visible when returning to the commit view from the regeneration prompt state.