### PR TITLE
fix: streamline summary generation with persistent hints

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -263,26 +263,26 @@ func (m *Model) getGitDiff() tea.Msg {
 }
 
 func (m *Model) generateSummary(diff string) tea.Cmd {
+	var systemInstruction string
+	var userPrompt string
+
+	// Split the systemPrompt into instructions and the diff template.
+	// The prompt.md format is: [Instructions] \n\n Diff follows: \n\n ```diff %s ``` ...
+	parts := strings.SplitN(m.systemPrompt, "Diff follows:", 2)
+	if len(parts) < 2 {
+		// Fallback if "Diff follows:" is not found in the prompt template.
+		systemInstruction = ""
+		userPrompt = fmt.Sprintf(m.systemPrompt, diff)
+	} else {
+		systemInstruction = strings.TrimSpace(parts[0])
+		userPrompt = fmt.Sprintf(parts[1], diff)
+	}
+
+	if m.hint != "" {
+		userPrompt += "\n\nCONTEXT HINT: " + m.hint
+	}
+
 	return func() tea.Msg {
-		var systemInstruction string
-		var userPrompt string
-
-		// Split the systemPrompt into instructions and the diff template.
-		// The prompt.md format is: [Instructions] \n\n Diff follows: \n\n ```diff %s ``` ...
-		parts := strings.SplitN(m.systemPrompt, "Diff follows:", 2)
-		if len(parts) < 2 {
-			// Fallback if "Diff follows:" is not found in the prompt template.
-			systemInstruction = ""
-			userPrompt = fmt.Sprintf(m.systemPrompt, diff)
-		} else {
-			systemInstruction = strings.TrimSpace(parts[0])
-			userPrompt = fmt.Sprintf(parts[1], diff)
-		}
-
-		if m.hint != "" {
-			userPrompt += "\n\nCONTEXT HINT: " + m.hint
-		}
-
 		start := time.Now()
 		resp, err := m.llmProvider.Call(m.ctx, systemInstruction, userPrompt)
 		duration := time.Since(start)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -119,7 +119,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			Blue.Render(")"),
 		)
 		m.diff = string(msg)
-		return m, m.generateSummary(m.diff, "")
+		return m, m.generateSummary(m.diff)
 
 	case llmResultMsg:
 		commitMessage := msg.content
@@ -164,6 +164,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.promptView = initialPromptViewModel(
 			Magenta.Render("Add an optional instruction to help shape regenerating the commit summary:"),
 			"ENTER to confirm, or ESC to cancel.",
+			m.hint,
 		)
 
 		return m, m.promptView.Init()
@@ -175,7 +176,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			Blue.Bold(true).Underline(true).Render(m.llmProvider.Model()),
 			Blue.Render(")"),
 		)
-		return m, tea.Batch(m.spinner.Tick, m.generateSummary(m.diff, string(msg)))
+		m.hint = string(msg)
+		return m, tea.Batch(m.spinner.Tick, m.generateSummary(m.diff))
 
 	case cancelRegenPromptMsg:
 		m.state = showCommitView
@@ -260,7 +262,7 @@ func (m *Model) getGitDiff() tea.Msg {
 	return gitDiffMsg(diff)
 }
 
-func (m *Model) generateSummary(diff string, userMessage string) tea.Cmd {
+func (m *Model) generateSummary(diff string) tea.Cmd {
 	return func() tea.Msg {
 		var systemInstruction string
 		var userPrompt string
@@ -279,9 +281,6 @@ func (m *Model) generateSummary(diff string, userMessage string) tea.Cmd {
 
 		if m.hint != "" {
 			userPrompt += "\n\nCONTEXT HINT: " + m.hint
-		}
-		if userMessage != "" {
-			userPrompt += "\n\n**IMPORTANT:** " + userMessage
 		}
 
 		start := time.Now()

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -9,9 +9,7 @@ import (
 
 	"charm.land/bubbles/v2/spinner"
 	"charm.land/bubbles/v2/textarea"
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
-	"github.com/charmbracelet/x/ansi"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -197,32 +195,29 @@ func TestModel_Update(t *testing.T) {
 		assert.IsType(t, tea.QuitMsg{}, cmd())
 	})
 
-	t.Run("regenerateMsg", func(t *testing.T) {
+	t.Run("regenerateMsg - initializes promptView with current hint", func(t *testing.T) {
 		m := initialModel()
-		m.state = showCommitView // Ensure state is showCommitView
+		m.state = showCommitView
+		m.hint = "current hint"
 
-		updatedModel, cmd := m.Update(regenerateMsg{})
+		updatedModel, _ := m.Update(regenerateMsg{})
 
 		assert.Equal(t, showRegeneratePrompt, updatedModel.(*Model).state)
-		assert.NotNil(t, updatedModel.(*Model).promptView)
-		assert.NotNil(t, cmd)
-		assert.IsType(t, textinput.Blink(), cmd())
+		pv, ok := updatedModel.(*Model).promptView.(*promptViewModel)
+		assert.True(t, ok)
+		assert.Equal(t, "current hint", pv.textinput.Value())
 	})
 
-	t.Run("userResponseMsg", func(t *testing.T) {
+	t.Run("userResponseMsg - updates m.hint", func(t *testing.T) {
 		m := initialModel()
-		m.state = showRegeneratePrompt // Ensure state is showRegeneratePrompt
+		m.state = showRegeneratePrompt
 		mockLLM.On("Model").Return("test-model").Once()
-		// The command returned by Update will execute llmProvider.Call later.
-		// No need to set mockLLM.On("Call") here.
 
-		userResponse := "make it shorter"
-		updatedModel, cmd := m.Update(userResponseMsg(userResponse))
+		userResponse := "new hint"
+		updatedModel, _ := m.Update(userResponseMsg(userResponse))
 
 		assert.Equal(t, showSpinner, updatedModel.(*Model).state)
-		assert.Contains(t, ansi.Strip(updatedModel.(*Model).spinnerMessage), "Re-generating commit summary (using: test-model)")
-		assert.IsType(t, tea.Batch(nil), cmd) // Should return tea.Batch(m.spinner.Tick, m.generateSummary)
-		mockLLM.AssertExpectations(t)
+		assert.Equal(t, "new hint", updatedModel.(*Model).hint)
 	})
 
 	t.Run("cancelRegenPromptMsg", func(t *testing.T) {

--- a/internal/ui/prompt_view.go
+++ b/internal/ui/prompt_view.go
@@ -16,6 +16,7 @@ func initialPromptViewModel(message, placeholder, hint string) *promptViewModel 
 	ti := textinput.New()
 	ti.Placeholder = placeholder
 	ti.SetValue(hint)
+	ti.CursorEnd()
 	ti.Prompt = "❯ "
 	ti.Focus()
 	ti.CharLimit = 156

--- a/internal/ui/prompt_view.go
+++ b/internal/ui/prompt_view.go
@@ -12,9 +12,10 @@ type promptViewModel struct {
 	textinput textinput.Model
 }
 
-func initialPromptViewModel(message, placeholder string) *promptViewModel {
+func initialPromptViewModel(message, placeholder, hint string) *promptViewModel {
 	ti := textinput.New()
 	ti.Placeholder = placeholder
+	ti.SetValue(hint)
 	ti.Prompt = "❯ "
 	ti.Focus()
 	ti.CharLimit = 156


### PR DESCRIPTION
*   Rework `generateSummary` to use the model's `m.hint` property directly, removing the redundant `userMessage` parameter.
*   Update `initialPromptViewModel` to pre-fill the input with the current `m.hint`, allowing users to edit previous instructions during regeneration.
*   Update unit tests to reflect the new state management logic for hints.