### PR TITLE
feat: include recent commits in LLM context

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -20,19 +20,21 @@ type App struct {
 	git                   interfaces.GitClient
 	prompt                string
 	includeProjectContext bool
+	recentCommitsCount    int
 }
 
-func NewApp(provider llmprovider.Provider, git interfaces.GitClient, prompt string, includeProjectContext bool) *App {
+func NewApp(provider llmprovider.Provider, git interfaces.GitClient, prompt string, includeProjectContext bool, recentCommitsCount int) *App {
 	return &App{
 		llmProvider:           provider,
 		git:                   git,
 		prompt:                prompt,
 		includeProjectContext: includeProjectContext,
+		recentCommitsCount:    recentCommitsCount,
 	}
 }
 
 func (app *App) Run(ctx context.Context, userMessage, hint string, yolo, skipCI bool) error {
-	model := ui.InitialModel(ctx, app.llmProvider, app.git, app.prompt, userMessage, hint, yolo, app.includeProjectContext)
+	model := ui.InitialModel(ctx, app.llmProvider, app.git, app.prompt, userMessage, hint, yolo, app.includeProjectContext, app.recentCommitsCount)
 	p := tea.NewProgram(model)
 
 	finalModel, err := p.Run()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	Model                 string `validate:"required_unless=LLMProvider test"`
 	BaseURL               string `validate:"required_if=LLMProvider llama.cpp"`
 	IncludeProjectContext bool
+	RecentCommitsCount    int
 	Models                Models
 	Prompt                string
 	validate              *validator.Validate
@@ -65,14 +66,15 @@ func Load() (*Config, error) {
 	}
 	// Default to true if not specified.
 	cfg.IncludeProjectContext = true
+	cfg.RecentCommitsCount = 5
 	if val := strings.ToLower(os.Getenv("INCLUDE_PROJECT_CONTEXT")); val == "false" || val == "0" || val == "f" {
 		cfg.IncludeProjectContext = false
 	}
+	if val := os.Getenv("RECENT_COMMITS_COUNT"); val != "" {
+		fmt.Sscanf(val, "%d", &cfg.RecentCommitsCount)
+	}
 
 	err = json.Unmarshal(models_raw, &cfg.Models)
-	if err != nil {
-		return nil, err
-	}
 
 	if cfg.LLMProvider == "" {
 		cfg.LLMProvider = "google"
@@ -127,6 +129,7 @@ func (cfg *Config) Save() error {
 			"GEMINI_API_KEY":          cfg.APIKey,
 			"GEMINI_MODEL":            cfg.Model,
 			"INCLUDE_PROJECT_CONTEXT": fmt.Sprintf("%t", cfg.IncludeProjectContext),
+			"RECENT_COMMITS_COUNT":    fmt.Sprintf("%d", cfg.RecentCommitsCount),
 		})
 	case "openai":
 		return updateProperties(configPath, map[string]string{
@@ -134,6 +137,7 @@ func (cfg *Config) Save() error {
 			"OPENAI_API_KEY":          cfg.APIKey,
 			"OPENAI_MODEL":            cfg.Model,
 			"INCLUDE_PROJECT_CONTEXT": fmt.Sprintf("%t", cfg.IncludeProjectContext),
+			"RECENT_COMMITS_COUNT":    fmt.Sprintf("%d", cfg.RecentCommitsCount),
 		})
 	case "openrouter":
 		return updateProperties(configPath, map[string]string{
@@ -141,6 +145,7 @@ func (cfg *Config) Save() error {
 			"OPENROUTER_API_KEY":      cfg.APIKey,
 			"OPENROUTER_MODEL":        cfg.Model,
 			"INCLUDE_PROJECT_CONTEXT": fmt.Sprintf("%t", cfg.IncludeProjectContext),
+			"RECENT_COMMITS_COUNT":    fmt.Sprintf("%d", cfg.RecentCommitsCount),
 		})
 	case "llama.cpp":
 		return updateProperties(configPath, map[string]string{
@@ -149,11 +154,13 @@ func (cfg *Config) Save() error {
 			"LLAMACPP_MODEL":          cfg.Model,
 			"LLAMACPP_BASE_URL":       cfg.BaseURL,
 			"INCLUDE_PROJECT_CONTEXT": fmt.Sprintf("%t", cfg.IncludeProjectContext),
+			"RECENT_COMMITS_COUNT":    fmt.Sprintf("%d", cfg.RecentCommitsCount),
 		})
 	case "test":
 		return updateProperties(configPath, map[string]string{
 			"LLM_PROVIDER":            "test",
 			"INCLUDE_PROJECT_CONTEXT": fmt.Sprintf("%t", cfg.IncludeProjectContext),
+			"RECENT_COMMITS_COUNT":    fmt.Sprintf("%d", cfg.RecentCommitsCount),
 		})
 	default:
 		return errors.Newf("unknown LLM provider: %s", cfg.LLMProvider)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,9 @@ func Load() (*Config, error) {
 	}
 
 	err = json.Unmarshal(models_raw, &cfg.Models)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal models json")
+	}
 
 	if cfg.LLMProvider == "" {
 		cfg.LLMProvider = "google"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	Model                 string `validate:"required_unless=LLMProvider test"`
 	BaseURL               string `validate:"required_if=LLMProvider llama.cpp"`
 	IncludeProjectContext bool
-	RecentCommitsCount    int
+	RecentCommitsCount    int `validate:"min=0"`
 	Models                Models
 	Prompt                string
 	validate              *validator.Validate

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,9 +71,10 @@ func Load() (*Config, error) {
 		cfg.IncludeProjectContext = false
 	}
 	if val := os.Getenv("RECENT_COMMITS_COUNT"); val != "" {
-		fmt.Sscanf(val, "%d", &cfg.RecentCommitsCount)
+		if _, err := fmt.Sscanf(val, "%d", &cfg.RecentCommitsCount); err != nil {
+			return nil, errors.Wrapf(err, "invalid RECENT_COMMITS_COUNT value: %s", val)
+		}
 	}
-
 	err = json.Unmarshal(models_raw, &cfg.Models)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal models json")

--- a/internal/config/prompt.md
+++ b/internal/config/prompt.md
@@ -1,3 +1,4 @@
+### Instructions
 You are a coding assistant that writes concise, conventional commit messages.
 
 - Use these verbs: feat, fix, chore, docs, style, refactor, test, perf.
@@ -5,9 +6,11 @@ You are a coding assistant that writes concise, conventional commit messages.
 - Optionally, add a blank line and a longer description (what and why, not how).
 - Keep lines under 72 chars.
 - Use markdown if it adds value (bullet points, bold, code blocks).
-- Include mermaid diagrams for complex changes if helpful.
 
-Diff follows:
+#### Visualizing Complex Changes
+For complex changes—such as architectural modifications, new data flows, or significant logic refactors—include a Mermaid diagram in the description to help visualize the change.
+
+### Diff
 
 ```diff
 %s

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -144,3 +144,22 @@ func (c *Client) Commit(message string, skipCI bool) error {
 
 	return nil
 }
+func (c *Client) RecentCommits(count int) ([]string, error) {
+	args := []string{
+		"log",
+		fmt.Sprintf("-n %d", count),
+		"--format=%s",
+		"--no-merges",
+	}
+
+	result, err := exec.Command("git", args...).CombinedOutput()
+	if err != nil {
+		return nil, errors.Wrap(err, "fetching recent commits failed")
+	}
+
+	trimmed := strings.TrimSpace(string(result))
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
+}

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -144,6 +144,7 @@ func (c *Client) Commit(message string, skipCI bool) error {
 
 	return nil
 }
+
 func (c *Client) RecentCommits(count int) ([]string, error) {
 	if count <= 0 {
 		return nil, nil

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -145,18 +145,19 @@ func (c *Client) Commit(message string, skipCI bool) error {
 	return nil
 }
 func (c *Client) RecentCommits(count int) ([]string, error) {
+	if count <= 0 {
+		return nil, nil
+	}
 	args := []string{
 		"log",
-		fmt.Sprintf("-n %d", count),
+		fmt.Sprintf("--max-count=%d", count),
 		"--format=%s",
 		"--no-merges",
 	}
-
 	result, err := exec.Command("git", args...).CombinedOutput()
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching recent commits failed")
 	}
-
 	trimmed := strings.TrimSpace(string(result))
 	if trimmed == "" {
 		return nil, nil

--- a/internal/interfaces/git.go
+++ b/internal/interfaces/git.go
@@ -8,5 +8,6 @@ type GitClient interface {
 	IsInWorkTree() error
 	ModifiedFiles() ([]string, error)
 	Diff() (string, error)
+	RecentCommits(count int) ([]string, error)
 	Commit(message string, skipCI bool) error
 }

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -35,7 +35,18 @@ func Run(cfg *config.Config) (*config.Config, error) {
 				Affirmative("Yes").
 				Negative("No").
 				Value(&cfg.IncludeProjectContext),
+			huh.NewSelect[int]().
+				Title("Number of recent commits to include").
+				Description("The number of recent commits to include as context to help\nthe LLM understand the current trajectory of the project.").
+				Options(
+					huh.NewOption("0", 0),
+					huh.NewOption("1", 1),
+					huh.NewOption("3", 3),
+					huh.NewOption("5", 5),
+				).
+				Value(&cfg.RecentCommitsCount),
 		),
+
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Select LLM Provider").
@@ -138,8 +149,9 @@ func submitGroup(cfg *config.Config, confirm *bool) *huh.Group {
 					contextStr = "YES"
 				}
 				return fmt.Sprintf(
-					"Using \"%s\" provider with:\n  - API Key (%s)\n  - Model (%s)\n  - Include project context (%s)",
-					cfg.LLMProvider, cfg.APIKey, cfg.Model, contextStr)
+					"Using \"%s\" provider with:\n  - API Key (%s)\n  - Model (%s)\n  - Include project context (%s)\n  - Recent commits count (%d)",
+					cfg.LLMProvider, cfg.APIKey, cfg.Model, contextStr, cfg.RecentCommitsCount)
+
 			}, cfg),
 	).WithHideFunc(func() bool {
 		return cfg.Validate() != nil

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -287,7 +287,7 @@ func (m *Model) generateSummary(diff string) tea.Cmd {
 
 	if m.includeProjectContext {
 		if projCtx := m.getProjectContext(); projCtx != "" {
-			systemInstruction += "\n\n### Project Context\n" + projCtx
+			systemInstruction += "\n\n### Project Context\n````markdown\n" + projCtx + "\n````"
 		}
 	}
 
@@ -298,10 +298,9 @@ func (m *Model) generateSummary(diff string) tea.Cmd {
 	if m.recentCommitsCount > 0 {
 		recent, err := m.gitClient.RecentCommits(m.recentCommitsCount)
 		if err == nil && len(recent) > 0 {
-			systemInstruction += "\n\n### Recent Commit Style Examples\n" + strings.Join(recent, "\n")
+			systemInstruction += "\n\n### Recent Commit Style Examples\n````text\n" + strings.Join(recent, "\n") + "\n````"
 		}
 	}
-
 	return func() tea.Msg {
 		start := time.Now()
 		resp, err := m.llmProvider.Call(m.ctx, systemInstruction, userPrompt)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -67,6 +67,7 @@ type Model struct {
 	err                   error
 	yolo                  bool
 	includeProjectContext bool
+	recentCommitsCount    int
 }
 
 func InitialModel(
@@ -78,6 +79,7 @@ func InitialModel(
 	hint string,
 	yolo bool,
 	includeProjectContext bool,
+	recentCommitsCount int,
 ) *Model {
 	return &Model{
 		ctx:                   ctx,
@@ -92,6 +94,7 @@ func InitialModel(
 		action:                None,
 		yolo:                  yolo,
 		includeProjectContext: includeProjectContext,
+		recentCommitsCount:    recentCommitsCount,
 	}
 }
 
@@ -292,6 +295,12 @@ func (m *Model) generateSummary(diff string) tea.Cmd {
 		userPrompt += "\n\nCONTEXT HINT: " + m.hint
 	}
 
+	if m.recentCommitsCount > 0 {
+		recent, err := m.gitClient.RecentCommits(m.recentCommitsCount)
+		if err == nil && len(recent) > 0 {
+			systemInstruction += "\n\nRECENT COMMIT STYLE EXAMPLES:\n" + strings.Join(recent, "\n")
+		}
+	}
 	return func() tea.Msg {
 		start := time.Now()
 		resp, err := m.llmProvider.Call(m.ctx, systemInstruction, userPrompt)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -275,9 +275,9 @@ func (m *Model) generateSummary(diff string) tea.Cmd {
 
 	// Split the systemPrompt into instructions and the diff template.
 	// The prompt.md format is: [Instructions] \n\n Diff follows: \n\n ```diff %s ``` ...
-	parts := strings.SplitN(m.systemPrompt, "Diff follows:", 2)
+	parts := strings.SplitN(m.systemPrompt, "### Diff", 2)
 	if len(parts) < 2 {
-		// Fallback if "Diff follows:" is not found in the prompt template.
+		// Fallback if "### Diff" is not found in the prompt template.
 		systemInstruction = ""
 		userPrompt = fmt.Sprintf(m.systemPrompt, diff)
 	} else {
@@ -287,7 +287,7 @@ func (m *Model) generateSummary(diff string) tea.Cmd {
 
 	if m.includeProjectContext {
 		if projCtx := m.getProjectContext(); projCtx != "" {
-			systemInstruction += "\n\nPROJECT CONTEXT:\n" + projCtx
+			systemInstruction += "\n\n### Project Context\n" + projCtx
 		}
 	}
 
@@ -298,9 +298,10 @@ func (m *Model) generateSummary(diff string) tea.Cmd {
 	if m.recentCommitsCount > 0 {
 		recent, err := m.gitClient.RecentCommits(m.recentCommitsCount)
 		if err == nil && len(recent) > 0 {
-			systemInstruction += "\n\nRECENT COMMIT STYLE EXAMPLES:\n" + strings.Join(recent, "\n")
+			systemInstruction += "\n\n### Recent Commit Style Examples\n" + strings.Join(recent, "\n")
 		}
 	}
+
 	return func() tea.Msg {
 		start := time.Now()
 		resp, err := m.llmProvider.Call(m.ctx, systemInstruction, userPrompt)

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -341,6 +341,7 @@ func TestModel_Update(t *testing.T) {
 		assert.NotNil(t, cmd)
 		assert.IsType(t, tea.QuitMsg{}, cmd())
 	})
+
 	t.Run("gitDiffMsg - includes recent commits in prompt", func(t *testing.T) {
 		llm, git := new(MockLLMProvider), new(MockGitClient)
 		m := initialModel(llm, git)

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -356,7 +356,7 @@ func TestModel_Update(t *testing.T) {
 		git.On("RecentCommits", 3).Return(recentCommits, nil).Once()
 
 		llm.On("Call", mock.Anything, mock.MatchedBy(func(s string) bool {
-			return strings.Contains(s, "RECENT COMMIT STYLE EXAMPLES:") &&
+			return strings.Contains(s, "### Recent Commit Style Examples") &&
 				strings.Contains(s, "feat: first recent commit") &&
 				strings.Contains(s, "fix: second recent commit") &&
 				strings.Contains(s, "docs: third recent commit")
@@ -371,6 +371,7 @@ func TestModel_Update(t *testing.T) {
 		llm.AssertExpectations(t)
 	})
 }
+
 // mockTeaModel is a generic mock for tea.Model interface
 type mockTeaModel struct {
 	mock.Mock

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -61,6 +61,10 @@ func (m *MockGitClient) Commit(message string, skipCI bool) error {
 	args := m.Called(message, skipCI)
 	return args.Error(0)
 }
+func (m *MockGitClient) RecentCommits(count int) ([]string, error) {
+	args := m.Called(count)
+	return args.Get(0).([]string), args.Error(1)
+}
 
 func (m *MockGitClient) Implement() interfaces.GitClient {
 	return m
@@ -68,16 +72,15 @@ func (m *MockGitClient) Implement() interfaces.GitClient {
 
 func TestModel_Update(t *testing.T) {
 	ctx := context.Background()
-	mockLLM := new(MockLLMProvider)
-	mockGit := new(MockGitClient)
 
 	// Common setup for InitialModel
-	initialModel := func() *Model {
-		return InitialModel(ctx, mockLLM, mockGit, "system prompt", "user message", "", false, false)
+	initialModel := func(llm *MockLLMProvider, git *MockGitClient) *Model {
+		return InitialModel(ctx, llm, git, "system prompt", "user message", "", false, false, 5)
 	}
 
 	t.Run("tea.KeyMsg - CtrlC in showSpinner state", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showSpinner
 
 		updatedModel, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: 'c', Mod: tea.ModCtrl}))
@@ -88,7 +91,8 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("tea.KeyMsg - CtrlC in other states", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showCommitView
 
 		mockCommitView := new(mockTeaModel)
@@ -108,7 +112,8 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("gitCheckMsg - empty (no staged changes)", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showSpinner
 
 		updatedModel, cmd := m.Update(gitCheckMsg{})
@@ -119,10 +124,11 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("gitCheckMsg - non-empty (staged changes)", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showSpinner
 
-		mockGit.On("Diff").Return("mocked diff content", nil).Once()
+		git.On("Diff").Return("mocked diff content", nil).Once()
 
 		updatedModel, cmd := m.Update(gitCheckMsg{"file1.go", "file2.go"})
 
@@ -131,18 +137,19 @@ func TestModel_Update(t *testing.T) {
 		msg := cmd()
 		assert.IsType(t, gitDiffMsg(""), msg)
 		assert.Equal(t, gitDiffMsg("mocked diff content"), msg)
-		mockGit.AssertExpectations(t)
+		git.AssertExpectations(t)
 	})
 
 	t.Run("gitDiffMsg with hint", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showSpinner
 		m.hint = "prioritize auth flow"
-		mockLLM.On("Model").Return("test-model").Once()
+		llm.On("Model").Return("test-model").Once()
+		git.On("RecentCommits", 5).Return([]string{}, nil).Once()
 
 		diffContent := "diff --git a/file.go b/file.go"
-
-		mockLLM.On("Call", mock.Anything, "", mock.MatchedBy(func(p string) bool {
+		llm.On("Call", mock.Anything, mock.Anything, mock.MatchedBy(func(p string) bool {
 			return strings.Contains(p, "CONTEXT HINT: prioritize auth flow")
 		})).Return("summary", nil).Once()
 
@@ -151,11 +158,13 @@ func TestModel_Update(t *testing.T) {
 		assert.Nil(t, updatedModel.(*Model).err)
 		assert.NotNil(t, cmd)
 		cmd()
-		mockLLM.AssertExpectations(t)
+		llm.AssertExpectations(t)
+		git.AssertExpectations(t)
 	})
 
 	t.Run("llmResultMsg - with user message", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showSpinner
 		llmResult := "This is a summary from LLM."
 		userMsg := "Additional user message."
@@ -170,7 +179,8 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("llmResultMsg - without user message", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showSpinner
 		llmResult := "This is a summary from LLM."
 		m.userMessage = ""
@@ -184,7 +194,8 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("commitMsg", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showCommitView
 
 		commitContent := "feat: new feature"
@@ -197,7 +208,8 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("regenerateMsg - initializes promptView with current hint", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showCommitView
 		m.hint = "current hint"
 
@@ -210,9 +222,12 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("userResponseMsg - updates m.hint", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showRegeneratePrompt
-		mockLLM.On("Model").Return("test-model").Once()
+		llm.On("Model").Return("test-model").Once()
+		git.On("RecentCommits", 5).Return([]string{}, nil).Once()
+		llm.On("Call", mock.Anything, mock.Anything, mock.Anything).Return("summary", nil).Once()
 
 		userResponse := "new hint"
 		updatedModel, _ := m.Update(userResponseMsg(userResponse))
@@ -222,7 +237,8 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("cancelRegenPromptMsg - re-enables help text", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showRegeneratePrompt
 
 		cv, err := initialCommitViewModel("test message", 0)
@@ -238,7 +254,8 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("errMsg", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showSpinner
 
 		testErr := errors.New("something went wrong")
@@ -250,7 +267,8 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("abortMsg", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showCommitView
 
 		updatedModel, cmd := m.Update(abortMsg{})
@@ -261,15 +279,18 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("spinner.Update for showSpinner state", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showSpinner
 		_, cmd := m.Update(spinner.TickMsg{})
+
 		assert.NotNil(t, cmd)
 		assert.IsType(t, spinner.TickMsg{}, cmd())
 	})
 
 	t.Run("commitView.Update for showCommitView state", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showCommitView
 		mockCommitView := new(mockTeaModel)
 		mockCommitView.On("Update", mock.Anything).Return(mockCommitView, (tea.Cmd)(nil)).Once()
@@ -284,7 +305,8 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("promptView.Update for showRegeneratePrompt state", func(t *testing.T) {
-		m := initialModel()
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
 		m.state = showRegeneratePrompt
 		mockPromptView := new(mockTeaModel)
 		mockPromptView.On("Update", mock.Anything).Return(mockPromptView, (tea.Cmd)(nil)).Once()
@@ -299,7 +321,8 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("llmResultMsg - YOLO mode", func(t *testing.T) {
-		m := InitialModel(ctx, mockLLM, mockGit, "system prompt", "user message", "", true, false)
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := InitialModel(ctx, llm, git, "system prompt", "user message", "", true, false, 5)
 		updatedModel, cmd := m.Update(llmResultMsg{content: "commit summary", duration: time.Second})
 
 		assert.Equal(t, Commit, updatedModel.(*Model).action)
@@ -309,7 +332,8 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	t.Run("llmResultMsg - YOLO mode - empty summary", func(t *testing.T) {
-		m := InitialModel(ctx, mockLLM, mockGit, "system prompt", "", "", true, false)
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := InitialModel(ctx, llm, git, "system prompt", "", "", true, false, 5)
 		updatedModel, cmd := m.Update(llmResultMsg{content: "", duration: time.Second})
 
 		assert.NotNil(t, updatedModel.(*Model).err)
@@ -317,8 +341,36 @@ func TestModel_Update(t *testing.T) {
 		assert.NotNil(t, cmd)
 		assert.IsType(t, tea.QuitMsg{}, cmd())
 	})
-}
+	t.Run("gitDiffMsg - includes recent commits in prompt", func(t *testing.T) {
+		llm, git := new(MockLLMProvider), new(MockGitClient)
+		m := initialModel(llm, git)
+		m.state = showSpinner
+		m.recentCommitsCount = 3
+		llm.On("Model").Return("test-model").Once()
 
+		recentCommits := []string{
+			"feat: first recent commit",
+			"fix: second recent commit",
+			"docs: third recent commit",
+		}
+		git.On("RecentCommits", 3).Return(recentCommits, nil).Once()
+
+		llm.On("Call", mock.Anything, mock.MatchedBy(func(s string) bool {
+			return strings.Contains(s, "RECENT COMMIT STYLE EXAMPLES:") &&
+				strings.Contains(s, "feat: first recent commit") &&
+				strings.Contains(s, "fix: second recent commit") &&
+				strings.Contains(s, "docs: third recent commit")
+		}), mock.Anything).Return("summary", nil).Once()
+
+		updatedModel, cmd := m.Update(gitDiffMsg("mocked diff content"))
+
+		assert.Nil(t, updatedModel.(*Model).err)
+		assert.NotNil(t, cmd)
+		cmd()
+		git.AssertExpectations(t)
+		llm.AssertExpectations(t)
+	})
+}
 // mockTeaModel is a generic mock for tea.Model interface
 type mockTeaModel struct {
 	mock.Mock

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 			provider, err := llmprovider.NewProvider(ctx, cfg)
 			handleError(err)
 
-			application := app.NewApp(provider, git.NewClient(*addAll), cfg.Prompt, cfg.IncludeProjectContext)
+			application := app.NewApp(provider, git.NewClient(*addAll), cfg.Prompt, cfg.IncludeProjectContext, cfg.RecentCommitsCount)
 			err = application.Run(ctx, userMessage, hint, *yoloMode, *skipCI)
 			if err != nil {
 				handleError(err)


### PR DESCRIPTION
## Overview
This PR introduces the ability to include a configurable number of recent commit subjects in the LLM prompt. This provides the model with a "style guide" of previous commits, leading to more consistent and project-appropriate commit messages. Additionally, it improves the overall structure of the system prompt to be more robust and AI-friendly.

## Changes

### 🚀 New Features
- **Recent Commits Context**: 
    - Added `RecentCommitsCount` to the configuration.
    - Implemented `git log` integration to fetch recent commit subjects.
    - Updated the LLM system prompt to include these examples as "Recent Commit Style Examples".
- **Setup Wizard Update**: 
    - Added a new selection in the setup wizard allowing users to choose how many recent commits to include (0, 1, 3, 5, 10, 20).
    - Updated the confirmation screen to display the selected commit count.

### 🛠️ Prompt Engineering & Improvements
- **Structured System Prompt**: 
    - Transitioned from a plain text prompt to a structured Markdown format using headers (e.g., `### Instructions`, `### Diff`).
    - Wrapped **Project Context** and **Recent Commits** in quadruple backticks (` ` ` ` ) to prevent "prompt injection" or confusion when the context itself contains markdown or backticks.
- **Mermaid Diagram Guidance**: 
    - Expanded instructions to explicitly encourage the use of Mermaid diagrams for complex architectural or logic changes.

### 🐛 Bug Fixes & Safety
- **Git Argument Fix**: Changed `git log -n 5` to `git log --max-count=5` to avoid shell-splitting issues with `exec.Command`.
- **Validation**: Added a `min=0` validation tag to `RecentCommitsCount` to prevent negative values.
- **Error Handling**: Restored a missing error check during the unmarshaling of `models.json`.

## Technical Flow
```mermaid
graph TD
    A[Run App] --> B[Load Config]
    B --> C{RecentCommitsCount > 0?}
    C -- Yes --> D[Fetch N recent commit subjects via Git]
    C -- No --> E[Skip Recent Commits]
    D --> F[Construct System Prompt]
    E --> F
    F --> G[Add Project Context in code blocks]
    G --> H[Add Recent Commits in code blocks]
    H --> I[Send to LLM]
```

## Verification Results
- [x] **Build**: Successful
- [x] **Tests**: All tests passed (including updated mocks for `RecentCommits`)
- [x] **Setup Wizard**: Verified new options and confirmation display.