### PR TITLE
refactor: propagate context through git operations

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -69,7 +69,7 @@ func (app *App) Run(ctx context.Context, userMessage, hint string, yolo, skipCI 
 			fmt.Println(m.CommitMessage())
 			fmt.Println()
 		}
-		err = app.git.Commit(m.CommitMessage(), skipCI)
+		err = app.git.Commit(ctx, m.CommitMessage(), skipCI)
 		if err != nil {
 			return err
 		}

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"context"
 
 	"github.com/cockroachdb/errors"
 )
@@ -19,8 +20,8 @@ func NewClient(addAll bool) *Client {
 	}
 }
 
-func (c *Client) IsInWorkTree() error {
-	result, err := exec.Command(
+func (c *Client) IsInWorkTree(ctx context.Context) error {
+	result, err := exec.CommandContext(ctx,
 		"git",
 		"rev-parse",
 		"--is-inside-work-tree",
@@ -39,7 +40,7 @@ func (c *Client) IsInWorkTree() error {
 	return nil
 }
 
-func (c *Client) ModifiedFiles() ([]string, error) {
+func (c *Client) ModifiedFiles(ctx context.Context) ([]string, error) {
 	args := []string{"diff", "--name-only"}
 	if c.addAll {
 		args = append(args, "HEAD")
@@ -47,7 +48,7 @@ func (c *Client) ModifiedFiles() ([]string, error) {
 		args = append(args, "--staged")
 	}
 
-	result, err := exec.Command("git", args...).CombinedOutput()
+	result, err := exec.CommandContext(ctx, "git", args...).CombinedOutput()
 	if err != nil {
 		return nil, errors.Wrap(err, "listing modified files failed")
 	}
@@ -59,7 +60,7 @@ func (c *Client) ModifiedFiles() ([]string, error) {
 	return strings.Split(trimmed, "\n"), nil
 }
 
-func (c *Client) Diff() (string, error) {
+func (c *Client) Diff(ctx context.Context) (string, error) {
 	args := []string{
 		"--no-pager",
 		"diff",
@@ -86,7 +87,7 @@ func (c *Client) Diff() (string, error) {
 		":(exclude)go.sum",
 	)
 
-	result, err := exec.Command("git", args...).CombinedOutput()
+	result, err := exec.CommandContext(ctx, "git", args...).CombinedOutput()
 	if err != nil {
 		return "", errors.Wrap(err, "git diff failed")
 	}
@@ -105,7 +106,7 @@ func (c *Client) prepareCommitMessage(message string, skipCI bool) string {
 	return message
 }
 
-func (c *Client) Commit(message string, skipCI bool) error {
+func (c *Client) Commit(ctx context.Context, message string, skipCI bool) error {
 	message = c.prepareCommitMessage(message, skipCI)
 
 	tmpfile, err := os.CreateTemp("", "gitmsg-*.txt")
@@ -122,30 +123,30 @@ func (c *Client) Commit(message string, skipCI bool) error {
 	if err := tmpfile.Close(); err != nil {
 		return errors.Wrap(err, "git commit failed")
 	}
-
+	
 	// Set up git commit command
 	args := []string{"commit"}
 	if c.addAll {
 		args = append(args, "-a")
 	}
 	args = append(args, "-F", tmpfile.Name())
-
-	cmd := exec.Command("git", args...)
-
+	
+	cmd := exec.CommandContext(ctx, "git", args...)
+	
 	// Connect stdout/stderr of git to our program’s stdout/stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin // allow interactive prompts (e.g., GPG signing, editor, etc.)
-
+	
 	// Run the command
 	if err := cmd.Run(); err != nil {
 		return errors.Wrap(err, "git commit failed")
 	}
-
+	
 	return nil
-}
+	}
 
-func (c *Client) RecentCommits(count int) ([]string, error) {
+func (c *Client) RecentCommits(ctx context.Context, count int) ([]string, error) {
 	if count <= 0 {
 		return nil, nil
 	}
@@ -155,7 +156,7 @@ func (c *Client) RecentCommits(count int) ([]string, error) {
 		"--format=%s",
 		"--no-merges",
 	}
-	result, err := exec.Command("git", args...).CombinedOutput()
+	result, err := exec.CommandContext(ctx, "git", args...).CombinedOutput()
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching recent commits failed")
 	}
@@ -164,4 +165,4 @@ func (c *Client) RecentCommits(count int) ([]string, error) {
 		return nil, nil
 	}
 	return strings.Split(trimmed, "\n"), nil
-}
+	}

--- a/internal/interfaces/git.go
+++ b/internal/interfaces/git.go
@@ -1,13 +1,16 @@
 package interfaces
 
-import "github.com/cockroachdb/errors"
+import (
+	"context"
+	"github.com/cockroachdb/errors"
+)
 
 var ErrAborted = errors.New("aborted")
 
 type GitClient interface {
-	IsInWorkTree() error
-	ModifiedFiles() ([]string, error)
-	Diff() (string, error)
-	RecentCommits(count int) ([]string, error)
-	Commit(message string, skipCI bool) error
+	IsInWorkTree(ctx context.Context) error
+	ModifiedFiles(ctx context.Context) ([]string, error)
+	Diff(ctx context.Context) (string, error)
+	RecentCommits(ctx context.Context, count int) ([]string, error)
+	Commit(ctx context.Context, message string, skipCI bool) error
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -301,8 +301,8 @@ func (m *Model) generateSummary(diff string) tea.Cmd {
 
 	if m.recentCommitsCount > 0 {
 		ctx, cancel := context.WithTimeout(m.ctx, 30*time.Second)
+		defer cancel()
 		recent, err := m.gitClient.RecentCommits(ctx, m.recentCommitsCount)
-		cancel()
 		if err == nil && len(recent) > 0 {
 			systemInstruction += "\n\n### Recent Commit Style Examples\n````text\n" + strings.Join(recent, "\n") + "\n````"
 		}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -251,10 +251,12 @@ func (m *Model) View() tea.View {
 
 func (m *Model) checkGitStatus() tea.Msg {
 	time.Sleep(500 * time.Millisecond) // Add a small delay
-	if err := m.gitClient.IsInWorkTree(); err != nil {
+	ctx, cancel := context.WithTimeout(m.ctx, 30*time.Second)
+	defer cancel()
+	if err := m.gitClient.IsInWorkTree(ctx); err != nil {
 		return errMsg{err}
 	}
-	modifiedFiles, err := m.gitClient.ModifiedFiles()
+	modifiedFiles, err := m.gitClient.ModifiedFiles(ctx)
 	if err != nil {
 		return errMsg{err}
 	}
@@ -262,7 +264,9 @@ func (m *Model) checkGitStatus() tea.Msg {
 }
 
 func (m *Model) getGitDiff() tea.Msg {
-	diff, err := m.gitClient.Diff()
+	ctx, cancel := context.WithTimeout(m.ctx, 30*time.Second)
+	defer cancel()
+	diff, err := m.gitClient.Diff(ctx)
 	if err != nil {
 		return errMsg{err}
 	}
@@ -296,14 +300,18 @@ func (m *Model) generateSummary(diff string) tea.Cmd {
 	}
 
 	if m.recentCommitsCount > 0 {
-		recent, err := m.gitClient.RecentCommits(m.recentCommitsCount)
+		ctx, cancel := context.WithTimeout(m.ctx, 30*time.Second)
+		recent, err := m.gitClient.RecentCommits(ctx, m.recentCommitsCount)
+		cancel()
 		if err == nil && len(recent) > 0 {
 			systemInstruction += "\n\n### Recent Commit Style Examples\n````text\n" + strings.Join(recent, "\n") + "\n````"
 		}
 	}
 	return func() tea.Msg {
 		start := time.Now()
-		resp, err := m.llmProvider.Call(m.ctx, systemInstruction, userPrompt)
+		ctx, cancel := context.WithTimeout(m.ctx, 60*time.Second)
+		defer cancel()
+		resp, err := m.llmProvider.Call(ctx, systemInstruction, userPrompt)
 		duration := time.Since(start)
 		if err != nil {
 			return errMsg{err}

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -42,27 +42,27 @@ type MockGitClient struct {
 	mock.Mock
 }
 
-func (m *MockGitClient) IsInWorkTree() error {
-	args := m.Called()
+func (m *MockGitClient) IsInWorkTree(ctx context.Context) error {
+	args := m.Called(ctx)
 	return args.Error(0)
 }
 
-func (m *MockGitClient) ModifiedFiles() ([]string, error) {
-	args := m.Called()
+func (m *MockGitClient) ModifiedFiles(ctx context.Context) ([]string, error) {
+	args := m.Called(ctx)
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *MockGitClient) Diff() (string, error) {
-	args := m.Called()
+func (m *MockGitClient) Diff(ctx context.Context) (string, error) {
+	args := m.Called(ctx)
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockGitClient) Commit(message string, skipCI bool) error {
-	args := m.Called(message, skipCI)
+func (m *MockGitClient) Commit(ctx context.Context, message string, skipCI bool) error {
+	args := m.Called(ctx, message, skipCI)
 	return args.Error(0)
 }
-func (m *MockGitClient) RecentCommits(count int) ([]string, error) {
-	args := m.Called(count)
+func (m *MockGitClient) RecentCommits(ctx context.Context, count int) ([]string, error) {
+	args := m.Called(ctx, count)
 	return args.Get(0).([]string), args.Error(1)
 }
 
@@ -128,7 +128,7 @@ func TestModel_Update(t *testing.T) {
 		m := initialModel(llm, git)
 		m.state = showSpinner
 
-		git.On("Diff").Return("mocked diff content", nil).Once()
+		git.On("Diff", mock.Anything).Return("mocked diff content", nil).Once()
 
 		updatedModel, cmd := m.Update(gitCheckMsg{"file1.go", "file2.go"})
 
@@ -146,7 +146,7 @@ func TestModel_Update(t *testing.T) {
 		m.state = showSpinner
 		m.hint = "prioritize auth flow"
 		llm.On("Model").Return("test-model").Once()
-		git.On("RecentCommits", 5).Return([]string{}, nil).Once()
+		git.On("RecentCommits", mock.Anything, 5).Return([]string{}, nil).Once()
 
 		diffContent := "diff --git a/file.go b/file.go"
 		llm.On("Call", mock.Anything, mock.Anything, mock.MatchedBy(func(p string) bool {
@@ -226,7 +226,7 @@ func TestModel_Update(t *testing.T) {
 		m := initialModel(llm, git)
 		m.state = showRegeneratePrompt
 		llm.On("Model").Return("test-model").Once()
-		git.On("RecentCommits", 5).Return([]string{}, nil).Once()
+		git.On("RecentCommits", mock.Anything, 5).Return([]string{}, nil).Once()
 		llm.On("Call", mock.Anything, mock.Anything, mock.Anything).Return("summary", nil).Once()
 
 		userResponse := "new hint"
@@ -354,7 +354,7 @@ func TestModel_Update(t *testing.T) {
 			"fix: second recent commit",
 			"docs: third recent commit",
 		}
-		git.On("RecentCommits", 3).Return(recentCommits, nil).Once()
+		git.On("RecentCommits", mock.Anything, 3).Return(recentCommits, nil).Once()
 
 		llm.On("Call", mock.Anything, mock.MatchedBy(func(s string) bool {
 			return strings.Contains(s, "### Recent Commit Style Examples") &&


### PR DESCRIPTION
- Update `GitClient` interface and implementations to accept `context.Context`
- Use `exec.CommandContext` for all git subprocesses
- Add timeouts to git and LLM operations to ensure long-running calls can be cancelled gracefully.

```mermaid
graph TD
    A[UI Model] -->|Pass Context| B[Git Client]
    B -->|Exec Command| C{System Git}
    B -->|Timeout| D[Context Cancellation]
    A -->|Timeout| E[LLM Provider]
```