### PR TITLE
feat: add `--no-verify` flag to skip git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ LLAMACPP_MODEL="Meta-Llama-3.1-8B-Instruct-Q4_K_M"
 | `--hint`         | `-H`      | Provide contextual guidance for the commit summary generation         |
 | `--llm-provider` |           | Override the `LLM_PROVIDER` environment variable                      |
 | `--message`      | `-m`      | Append a message to the commit summary                                |
+| `--no-verify`    |           | Skip git commit pre-verify hooks                                       |
 | `--setup-wizard` |           | Run the interactive setup wizard                                      |
 | `--skip-ci`      |           | Append `[skip ci]` to the first line of the commit message to skip CI |
 | `--version`      | `-v`      | Display version                                                       |

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ LLAMACPP_MODEL="Meta-Llama-3.1-8B-Instruct-Q4_K_M"
 | `--hint`         | `-H`      | Provide contextual guidance for the commit summary generation         |
 | `--llm-provider` |           | Override the `LLM_PROVIDER` environment variable                      |
 | `--message`      | `-m`      | Append a message to the commit summary                                |
-| `--no-verify`    |           | Skip git commit pre-verify hooks                                       |
+| `--no-verify`    |           | Bypass pre-commit and commit-msg hooks                                |
 | `--setup-wizard` |           | Run the interactive setup wizard                                      |
 | `--skip-ci`      |           | Append `[skip ci]` to the first line of the commit message to skip CI |
 | `--version`      | `-v`      | Display version                                                       |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,6 +23,14 @@ type App struct {
 	recentCommitsCount    int
 }
 
+type RunOptions struct {
+	UserMessage string
+	Hint        string
+	Yolo        bool
+	SkipCI      bool
+	NoVerify    bool
+}
+
 func NewApp(provider llmprovider.Provider, git interfaces.GitClient, prompt string, includeProjectContext bool, recentCommitsCount int) *App {
 	return &App{
 		llmProvider:           provider,
@@ -33,8 +41,8 @@ func NewApp(provider llmprovider.Provider, git interfaces.GitClient, prompt stri
 	}
 }
 
-func (app *App) Run(ctx context.Context, userMessage, hint string, yolo, skipCI, noVerify bool) error {
-	model := ui.InitialModel(ctx, app.llmProvider, app.git, app.prompt, userMessage, hint, yolo, app.includeProjectContext, app.recentCommitsCount)
+func (app *App) Run(ctx context.Context, opts *RunOptions) error {
+	model := ui.InitialModel(ctx, app.llmProvider, app.git, app.prompt, opts.UserMessage, opts.Hint, opts.Yolo, app.includeProjectContext, app.recentCommitsCount)
 	p := tea.NewProgram(model)
 
 	finalModel, err := p.Run()
@@ -64,12 +72,12 @@ func (app *App) Run(ctx context.Context, userMessage, hint string, yolo, skipCI,
 	}
 
 	if m.Action() == ui.Commit {
-		if yolo {
+		if opts.Yolo {
 			fmt.Println(ui.Green.Bold(true).Render("COMMIT MESSAGE:"))
 			fmt.Println(m.CommitMessage())
 			fmt.Println()
 		}
-		err = app.git.Commit(ctx, m.CommitMessage(), skipCI, noVerify)
+		err = app.git.Commit(ctx, m.CommitMessage(), opts.SkipCI, opts.NoVerify)
 		if err != nil {
 			return err
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -33,7 +33,7 @@ func NewApp(provider llmprovider.Provider, git interfaces.GitClient, prompt stri
 	}
 }
 
-func (app *App) Run(ctx context.Context, userMessage, hint string, yolo, skipCI bool) error {
+func (app *App) Run(ctx context.Context, userMessage, hint string, yolo, skipCI, noVerify bool) error {
 	model := ui.InitialModel(ctx, app.llmProvider, app.git, app.prompt, userMessage, hint, yolo, app.includeProjectContext, app.recentCommitsCount)
 	p := tea.NewProgram(model)
 
@@ -69,7 +69,7 @@ func (app *App) Run(ctx context.Context, userMessage, hint string, yolo, skipCI 
 			fmt.Println(m.CommitMessage())
 			fmt.Println()
 		}
-		err = app.git.Commit(ctx, m.CommitMessage(), skipCI)
+		err = app.git.Commit(ctx, m.CommitMessage(), skipCI, noVerify)
 		if err != nil {
 			return err
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -41,7 +41,7 @@ func NewApp(provider llmprovider.Provider, git interfaces.GitClient, prompt stri
 	}
 }
 
-func (app *App) Run(ctx context.Context, opts *RunOptions) error {
+func (app *App) Run(ctx context.Context, opts RunOptions) error {
 	model := ui.InitialModel(ctx, app.llmProvider, app.git, app.prompt, opts.UserMessage, opts.Hint, opts.Yolo, app.includeProjectContext, app.recentCommitsCount)
 	p := tea.NewProgram(model)
 

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -148,7 +148,7 @@ func (c *Client) prepareCommitMessage(message string, skipCI bool) string {
 	return message
 }
 
-func (c *Client) Commit(ctx context.Context, message string, skipCI bool) error {
+func (c *Client) Commit(ctx context.Context, message string, skipCI, noVerify bool) error {
 	message = c.prepareCommitMessage(message, skipCI)
 
 	tmpfile, err := os.CreateTemp("", "gitmsg-*.txt")
@@ -170,6 +170,9 @@ func (c *Client) Commit(ctx context.Context, message string, skipCI bool) error 
 	args := []string{"commit"}
 	if c.addAll {
 		args = append(args, "-a")
+	}
+	if noVerify {
+		args = append(args, "--no-verify")
 	}
 	args = append(args, "-F", tmpfile.Name())
 

--- a/internal/interfaces/git.go
+++ b/internal/interfaces/git.go
@@ -12,5 +12,5 @@ type GitClient interface {
 	ModifiedFiles(ctx context.Context) ([]string, error)
 	Diff(ctx context.Context, color, exclude bool) (string, error)
 	RecentCommits(ctx context.Context, count int) ([]string, error)
-	Commit(ctx context.Context, message string, skipCI bool) error
+	Commit(ctx context.Context, message string, skipCI, noVerify bool) error
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -57,8 +57,8 @@ func (m *MockGitClient) Diff(ctx context.Context, color, exclude bool) (string, 
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockGitClient) Commit(ctx context.Context, message string, skipCI bool) error {
-	args := m.Called(ctx, message, skipCI)
+func (m *MockGitClient) Commit(ctx context.Context, message string, skipCI, noVerify bool) error {
+	args := m.Called(ctx, message, skipCI, noVerify)
 	return args.Error(0)
 }
 func (m *MockGitClient) RecentCommits(ctx context.Context, count int) ([]string, error) {

--- a/main.go
+++ b/main.go
@@ -21,15 +21,12 @@ func main() {
 	cfg, err := config.Load()
 	handleError(err)
 
-	var userMessage string
 	var llmProvider string
 	var runSetupWizard *bool
 	var showVersion *bool
-	var yoloMode *bool
 	var addAll *bool
-	var skipCI *bool
-	var noVerify bool
-	var hint string
+
+	runOptions := &app.RunOptions{}
 
 	rootCmd := &cobra.Command{
 		Use:   "git-commit-summary",
@@ -66,22 +63,19 @@ func main() {
 			handleError(err)
 
 			application := app.NewApp(provider, git.NewClient(*addAll), cfg.Prompt, cfg.IncludeProjectContext, cfg.RecentCommitsCount)
-			err = application.Run(ctx, userMessage, hint, *yoloMode, *skipCI, noVerify)
-			if err != nil {
-				handleError(err)
-			}
+			err = application.Run(ctx, runOptions)
 		},
 	}
 
 	showVersion = rootCmd.PersistentFlags().BoolP("version", "v", false, "Display version information")
 	runSetupWizard = rootCmd.PersistentFlags().Bool("setup-wizard", false, "Run setup wizard")
-	yoloMode = rootCmd.PersistentFlags().Bool("yolo", false, "Commit immediately without asking for confirmation")
 	addAll = rootCmd.PersistentFlags().BoolP("all", "a", false, "Add all tracked files to the commit")
-	skipCI = rootCmd.PersistentFlags().Bool("skip-ci", false, "Append [skip ci] to the commit message")
-	rootCmd.PersistentFlags().BoolVar(&noVerify, "no-verify", false, "Bypass pre-commit and commit-msg hooks")
-	rootCmd.PersistentFlags().StringVarP(&userMessage, "message", "m", "", "Append a message to the commit summary")
+	rootCmd.PersistentFlags().BoolVar(&runOptions.Yolo, "yolo", false, "Commit immediately without asking for confirmation")
+	rootCmd.PersistentFlags().BoolVar(&runOptions.SkipCI, "skip-ci", false, "Append [skip ci] to the commit message")
+	rootCmd.PersistentFlags().BoolVar(&runOptions.NoVerify, "no-verify", false, "Bypass pre-commit and commit-msg hooks")
+	rootCmd.PersistentFlags().StringVarP(&runOptions.UserMessage, "message", "m", "", "Append a message to the commit summary")
+	rootCmd.PersistentFlags().StringVarP(&runOptions.Hint, "hint", "H", "", "Provide contextual guidance for the commit summary generation")
 	rootCmd.PersistentFlags().StringVar(&llmProvider, "llm-provider", cfg.LLMProvider, "Use specific LLM provider, overrides environment variable LLM_PROVIDER")
-	rootCmd.PersistentFlags().StringVarP(&hint, "hint", "H", "", "Provide contextual guidance for the commit summary generation")
 
 	_ = rootCmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 			handleError(err)
 
 			application := app.NewApp(provider, git.NewClient(*addAll), cfg.Prompt, cfg.IncludeProjectContext, cfg.RecentCommitsCount)
-			err = application.Run(ctx, userMessage, hint, *yoloMode, *skipCI, *noVerify)
+			err = application.Run(ctx, userMessage, hint, *yoloMode, *skipCI, noVerify)
 			if err != nil {
 				handleError(err)
 			}

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 	yoloMode = rootCmd.PersistentFlags().Bool("yolo", false, "Commit immediately without asking for confirmation")
 	addAll = rootCmd.PersistentFlags().BoolP("all", "a", false, "Add all tracked files to the commit")
 	skipCI = rootCmd.PersistentFlags().Bool("skip-ci", false, "Append [skip ci] to the commit message")
-	noVerify = rootCmd.PersistentFlags().Bool("no-verify", false, "Skip git commit pre-verify hooks")
+	rootCmd.PersistentFlags().BoolVar(&noVerify, "no-verify", false, "Bypass pre-commit and commit-msg hooks")
 	rootCmd.PersistentFlags().StringVarP(&userMessage, "message", "m", "", "Append a message to the commit summary")
 	rootCmd.PersistentFlags().StringVar(&llmProvider, "llm-provider", cfg.LLMProvider, "Use specific LLM provider, overrides environment variable LLM_PROVIDER")
 	rootCmd.PersistentFlags().StringVarP(&hint, "hint", "H", "", "Provide contextual guidance for the commit summary generation")

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 	var yoloMode *bool
 	var addAll *bool
 	var skipCI *bool
-	var noVerify *bool
+	var noVerify bool
 	var hint string
 
 	rootCmd := &cobra.Command{

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	var showVersion *bool
 	var addAll *bool
 
-	runOptions := &app.RunOptions{}
+	runOptions := app.RunOptions{}
 
 	rootCmd := &cobra.Command{
 		Use:   "git-commit-summary",
@@ -64,6 +64,7 @@ func main() {
 
 			application := app.NewApp(provider, git.NewClient(*addAll), cfg.Prompt, cfg.IncludeProjectContext, cfg.RecentCommitsCount)
 			err = application.Run(ctx, runOptions)
+			handleError(err)
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func main() {
 	var yoloMode *bool
 	var addAll *bool
 	var skipCI *bool
+	var noVerify *bool
 	var hint string
 
 	rootCmd := &cobra.Command{
@@ -65,7 +66,7 @@ func main() {
 			handleError(err)
 
 			application := app.NewApp(provider, git.NewClient(*addAll), cfg.Prompt, cfg.IncludeProjectContext, cfg.RecentCommitsCount)
-			err = application.Run(ctx, userMessage, hint, *yoloMode, *skipCI)
+			err = application.Run(ctx, userMessage, hint, *yoloMode, *skipCI, *noVerify)
 			if err != nil {
 				handleError(err)
 			}
@@ -77,6 +78,7 @@ func main() {
 	yoloMode = rootCmd.PersistentFlags().Bool("yolo", false, "Commit immediately without asking for confirmation")
 	addAll = rootCmd.PersistentFlags().BoolP("all", "a", false, "Add all tracked files to the commit")
 	skipCI = rootCmd.PersistentFlags().Bool("skip-ci", false, "Append [skip ci] to the commit message")
+	noVerify = rootCmd.PersistentFlags().Bool("no-verify", false, "Skip git commit pre-verify hooks")
 	rootCmd.PersistentFlags().StringVarP(&userMessage, "message", "m", "", "Append a message to the commit summary")
 	rootCmd.PersistentFlags().StringVar(&llmProvider, "llm-provider", cfg.LLMProvider, "Use specific LLM provider, overrides environment variable LLM_PROVIDER")
 	rootCmd.PersistentFlags().StringVarP(&hint, "hint", "H", "", "Provide contextual guidance for the commit summary generation")


### PR DESCRIPTION
Introduced the `--no-verify` flag to allow bypassing pre-commit or commit-msg hooks during the commit process, mirroring native git functionality. Updated the CLI parser, application flow, and internal Git client to propagate this option.