### PR TITLE
refactor: trim trailing whitespace from commit message

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -149,6 +149,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Quit
 			}
 		}
+		commitMessage = trimTrailingSpaces(commitMessage)
 		commitMessage = strings.ReplaceAll(commitMessage, "\n\n\n", "\n\n")
 
 		if m.yolo {
@@ -376,4 +377,12 @@ func (m *Model) Action() Action {
 
 func (m *Model) CommitMessage() string {
 	return m.commitMessage
+}
+
+func trimTrailingSpaces(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " \t\r")
+	}
+	return strings.Join(lines, "\n")
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -61,6 +61,7 @@ func (m *MockGitClient) Commit(ctx context.Context, message string, skipCI, noVe
 	args := m.Called(ctx, message, skipCI, noVerify)
 	return args.Error(0)
 }
+
 func (m *MockGitClient) RecentCommits(ctx context.Context, count int) ([]string, error) {
 	args := m.Called(ctx, count)
 	return args.Get(0).([]string), args.Error(1)
@@ -417,4 +418,24 @@ func (m *mockTeaModel) View() tea.View {
 		}
 	}
 	return tea.NewView("")
+}
+
+func TestTrimTrailingSpaces(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"no trailing spaces", "hello\nworld", "hello\nworld"},
+		{"trailing spaces on some lines", "hello  \nworld \n ", "hello\nworld\n"},
+		{"tabs and carriage returns", "line1\t\r\nline2  \n", "line1\nline2\n"},
+		{"empty string", "", ""},
+		{"single line with space", "hello ", "hello"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, trimTrailingSpaces(tt.input))
+		})
+	}
 }


### PR DESCRIPTION
Ensures cleaner commit messages by stripping trailing spaces, tabs, and carriage returns from each line before processing. Added a helper function with corresponding unit tests to verify behavior.

This was causing some glitches with bubbletea text component too.