### PR TITLE
feat: add configurable file ignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Tired of writing git commit messages? This tool uses AI ✨ to automatically gen
 - **Interactive Confirmation:** Prompts you to confirm the commit message before committing.
 - **Auto-completion:** Supports shell auto-completion for flags in Bash and Zsh.
 - **Multiple LLM Providers:** Supports Google Gemini, OpenAI, OpenRouter, and local Llama.cpp instances.
+- **Exclusion Lists:** Easily ignore specific files or patterns via `.gitcommitsummaryignore` files.
 - **Raw Diff View:** Quickly review your staged changes with a colored diff directly within the editor.
 - **Setup Wizard:** Easy configuration with an interactive setup wizard.
 
@@ -122,6 +123,10 @@ LLAMACPP_MODEL="Meta-Llama-3.1-8B-Instruct-Q4_K_M"
 | `--version`        | `-v`      | Display version                                                       |
 | `--yolo`           |           | Commit immediately without asking for confirmation                    |
 | `--zsh`            |           | Generate zsh completion script                                        |
+
+## Ignoring Files
+
+You can exclude specific files or patterns from analysis by creating a `.gitcommitsummaryignore` file. For more details, see [docs/exclusions.md](./docs/exclusions.md).
 
 ## Git Alias
 

--- a/docs/exclusions.md
+++ b/docs/exclusions.md
@@ -1,0 +1,37 @@
+# Excluding files from summary
+
+The `git-commit-summary` tool supports excluding specific files or patterns from the generated commit summaries. This is useful for ignoring generated files, lockfiles, or sensitive data that shouldn't be part of the summary analysis.
+
+## How it works
+
+The tool searches for a file named `.gitcommitsummaryignore` in the following locations, merging the rules found:
+
+1.  **Project Root:** Looks for `.gitcommitsummaryignore` starting from the current working directory and traversing up to the Git repository root.
+2.  **User Home:** Looks for `~/.gitcommitsummaryignore`.
+3.  **XDG Config:** Looks for `~/.config/git-commit-summary/.gitcommitsummaryignore` (respecting XDG Base Directory Specification).
+
+## File Format
+
+The `.gitcommitsummaryignore` file uses a simple line-based format:
+
+*   Each line is a glob pattern to be ignored.
+*   Lines starting with `#` or containing `//` are treated as comments and ignored.
+*   Empty lines are ignored.
+*   Only valid `path.Match` patterns are supported.
+*   Patterns starting with `!` (negation) are currently not supported.
+*   Backslashes `\` are not allowed.
+
+## Example
+
+```text
+# Ignore dependency lock files
+package-lock.json
+yarn.lock
+go.sum
+
+# Ignore generated code
+generated/*.go
+
+# Ignore documentation images
+docs/*.png
+```

--- a/internal/git/.gitcommitsummaryignore
+++ b/internal/git/.gitcommitsummaryignore
@@ -1,0 +1,8 @@
+*-lock.*
+*.lock
+.yarn/releases/**
+**/build/**
+**/dist/**
+**/target/**
+**/out/**
+go.sum

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"fmt"
 	"io"
 	"os"
@@ -122,16 +123,10 @@ func (c *Client) diffArgs(color, exclude bool) []string {
 	if exclude {
 		args = append(args,
 			"--diff-filter=ACMRTUXBD",
-			"--",                 // separates options from pathspecs
-			".",                  // include everything under the repo root
-			":(exclude)*-lock.*", // package-lock.json, pnpm-lock.yaml, etc.
-			":(exclude)*.lock",   // yarn.lock, poetry.lock, Cargo.lock, etc.
-			":(exclude)**/build/**",
-			":(exclude)**/dist/**",
-			":(exclude)**/target/**",
-			":(exclude)**/out/**",
-			":(exclude)go.sum",
+			"--", // separates options from pathspecs
+			".",  // include everything under the repo root
 		)
+		args = append(args, exclusions()...)
 	}
 	return args
 }

--- a/internal/git/exclusions.go
+++ b/internal/git/exclusions.go
@@ -89,7 +89,7 @@ func userHomeGitCommitSummaryIgnore() string {
 }
 
 func xdgConfigGitCommitSummaryIgnore() string {
-	config, err := xdg.ConfigFile("git-commit-summary/.gitcommitsummaryignore")
+	config, err := xdg.SearchConfigFile("git-commit-summary/.gitcommitsummaryignore")
 	if err != nil {
 		return ""
 	}

--- a/internal/git/exclusions.go
+++ b/internal/git/exclusions.go
@@ -66,8 +66,8 @@ func projectGitCommitSummaryIgnore() string {
 
 	for {
 		ignorePath := filepath.Join(cwd, ".gitcommitsummaryignore")
-		if content := readFileString(ignorePath); content != "" {
-			return content
+		if data, err := os.ReadFile(ignorePath); err == nil {
+			return string(data)
 		}
 
 		parent := filepath.Dir(cwd)

--- a/internal/git/exclusions.go
+++ b/internal/git/exclusions.go
@@ -1,0 +1,120 @@
+package git
+
+import (
+	_ "embed"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/adrg/xdg"
+)
+
+//go:embed .gitcommitsummaryignore
+var defaultGitCommitSummaryIgnore string
+
+func exclusions() []string {
+	var excludes []string
+	for _, content := range []string{
+		defaultGitCommitSummaryIgnore,
+		userHomeGitCommitSummaryIgnore(),
+		projectGitCommitSummaryIgnore(),
+		xdgConfigGitCommitSummaryIgnore(),
+	} {
+		for line := range strings.SplitSeq(content, "\n") {
+			// remove any comment (hash or double-slash) at the end of the line
+			if idx := strings.Index(line, "#"); idx != -1 {
+				line = line[:idx]
+			}
+
+			if idx := strings.Index(line, "//"); idx != -1 {
+				line = line[:idx]
+			}
+
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+
+			if !validateIgnorePattern(line) {
+				continue
+			}
+
+			excludes = append(excludes, ":(exclude)"+line)
+		}
+	}
+	return dedupe(excludes)
+}
+
+func dedupe(excludes []string) []string {
+	seen := make(map[string]struct{})
+	var result []string
+	for _, exclude := range excludes {
+		if _, ok := seen[exclude]; !ok {
+			seen[exclude] = struct{}{}
+			result = append(result, exclude)
+		}
+	}
+	return result
+}
+
+func projectGitCommitSummaryIgnore() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+
+	for {
+		ignorePath := filepath.Join(cwd, ".gitcommitsummaryignore")
+		if content := readFileString(ignorePath); content != "" {
+			return content
+		}
+
+		parent := filepath.Dir(cwd)
+		if parent == cwd {
+			break
+		}
+		cwd = parent
+	}
+
+	return ""
+}
+
+func userHomeGitCommitSummaryIgnore() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return readFileString(filepath.Join(homeDir, ".gitcommitsummaryignore"))
+}
+
+func xdgConfigGitCommitSummaryIgnore() string {
+	config, err := xdg.ConfigFile("git-commit-summary/.gitcommitsummaryignore")
+	if err != nil {
+		return ""
+	}
+	return readFileString(config)
+}
+
+func validateIgnorePattern(pattern string) bool {
+	if strings.ContainsRune(pattern, 0) {
+		return false
+	}
+	if strings.HasPrefix(pattern, "!") {
+		return false
+	}
+	if strings.Contains(pattern, "\\") {
+		return false
+	}
+
+	_, err := path.Match(pattern, pattern)
+	return err == nil
+}
+
+func readFileString(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}

--- a/internal/git/exclusions_test.go
+++ b/internal/git/exclusions_test.go
@@ -1,0 +1,57 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectGitCommitSummaryIgnore(t *testing.T) {
+	tempDir := t.TempDir()
+	repoDir := filepath.Join(tempDir, "repo", "subdir")
+	assert.NoError(t, os.MkdirAll(repoDir, 0o755))
+
+	ignoreFile := filepath.Join(tempDir, "repo", ".gitcommitsummaryignore")
+	assert.NoError(t, os.WriteFile(ignoreFile, []byte("ignored-file.txt\n"), 0o644))
+
+	current, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(repoDir))
+	defer func() {
+		_ = os.Chdir(current)
+	}()
+
+	actual := projectGitCommitSummaryIgnore()
+	assert.Equal(t, "ignored-file.txt\n", actual)
+}
+
+func TestUserHomeGitCommitSummaryIgnore(t *testing.T) {
+	tempHome := t.TempDir()
+	assert.NoError(t, os.Setenv("HOME", tempHome))
+
+	ignoreFile := filepath.Join(tempHome, ".gitcommitsummaryignore")
+	assert.NoError(t, os.WriteFile(ignoreFile, []byte("*.secret\n"), 0o644))
+
+	actual := userHomeGitCommitSummaryIgnore()
+	assert.Equal(t, "*.secret\n", actual)
+}
+
+func TestValidateIgnorePattern_InvalidGlob(t *testing.T) {
+	assert.False(t, validateIgnorePattern("[unclosed.glob"))
+}
+
+func TestDedupeExclusions(t *testing.T) {
+	excludes := []string{
+		":(exclude)foo.txt",
+		":(exclude)bar.txt",
+		":(exclude)foo.txt",
+	}
+
+	result := dedupe(excludes)
+	assert.Equal(t, []string{
+		":(exclude)foo.txt",
+		":(exclude)bar.txt",
+	}, result)
+}

--- a/internal/git/exclusions_test.go
+++ b/internal/git/exclusions_test.go
@@ -24,7 +24,8 @@ func TestProjectGitCommitSummaryIgnore(t *testing.T) {
 
 func TestUserHomeGitCommitSummaryIgnore(t *testing.T) {
 	tempHome := t.TempDir()
-	assert.NoError(t, os.Setenv("HOME", tempHome))
+	t.Setenv("HOME", tempHome)
+	t.Setenv("USERPROFILE", tempHome)
 
 	ignoreFile := filepath.Join(tempHome, ".gitcommitsummaryignore")
 	assert.NoError(t, os.WriteFile(ignoreFile, []byte("*.secret\n"), 0o644))

--- a/internal/git/exclusions_test.go
+++ b/internal/git/exclusions_test.go
@@ -16,12 +16,7 @@ func TestProjectGitCommitSummaryIgnore(t *testing.T) {
 	ignoreFile := filepath.Join(tempDir, "repo", ".gitcommitsummaryignore")
 	assert.NoError(t, os.WriteFile(ignoreFile, []byte("ignored-file.txt\n"), 0o644))
 
-	current, err := os.Getwd()
-	assert.NoError(t, err)
-	assert.NoError(t, os.Chdir(repoDir))
-	defer func() {
-		_ = os.Chdir(current)
-	}()
+	t.Chdir(repoDir)
 
 	actual := projectGitCommitSummaryIgnore()
 	assert.Equal(t, "ignored-file.txt\n", actual)


### PR DESCRIPTION
Introduce a `.gitcommitsummaryignore` system to exclude files from git diffs. Exclusions are resolved from multiple locations (default, home, XDG config, and project root) to provide better control over what is analyzed by the LLM.

```mermaid
graph LR
    A[Default Patterns] --> D(Exclusion Resolver)
    B[~/.gitcommitsummaryignore] --> D
    C[./.gitcommitsummaryignore] --> D
    D --> E{Git Diff Args}
    E --> F[Excluded Files]
```