### PR TITLE
fix: use absolute pathspec for git diff

### DIFF
--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -123,7 +123,7 @@ func (c *Client) diffArgs(color, exclude bool) []string {
 		args = append(args,
 			"--diff-filter=ACMRTUXBD",
 			"--",                 // separates options from pathspecs
-			".",                  // include everything under the repo root
+			":/",                 // include everything under the repo root
 			":(exclude)*-lock.*", // package-lock.json, pnpm-lock.yaml, etc.
 			":(exclude)*.lock",   // yarn.lock, poetry.lock, Cargo.lock, etc.
 			":(exclude)**/build/**",

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -6,6 +6,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestClient_diffArgs(t *testing.T) {
+	client := NewClient(false)
+	args := client.diffArgs(false, true)
+
+	// Check that :/ is in the args after the separator --
+	found := false
+	for i, arg := range args {
+		if arg == "--" && i+1 < len(args) && args[i+1] == ":/" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Expected :/ to be present after -- separator in diffArgs")
+}
+
 func TestClient_prepareCommitMessage(t *testing.T) {
 	client := NewClient(false)
 


### PR DESCRIPTION
Update the `diffArgs` to use the `:/` pathspec instead of `.` to ensure staged changes are correctly captured regardless of the current working directory within the git repository.

- Added a regression test to verify the inclusion of `:/` in the generated git diff arguments.